### PR TITLE
Create travel member fund from joint work

### DIFF
--- a/MEMBER_TRAVEL_FUND.MD
+++ b/MEMBER_TRAVEL_FUND.MD
@@ -6,12 +6,13 @@ and the Node.js Foundation projects.
 
 ## Restrictions
 
-* Candidates must be an indvidual member of the Node.js Foundation.
+* Candidates must be an individual member of the Node.js Foundation.
 
 ## Process
 
 Any member can apply for travel funds. Each request may take up to a month
-for the Admin members to approve or decline.
+for the [Admin members](https://github.com/nodejs/admin#governance-and-current-members)
+to approve or decline.
 
 ### Request
 * Open a pull request against this repository which adds an entry to the table at the bottom of this file.
@@ -20,12 +21,12 @@ for the Admin members to approve or decline.
  * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
   * Reimbursement stipends are expected to vary with travel distance.
-  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/commcomm-members. 
+  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/community-committee.  
   If unsure, just pick one, and that group will tag with the other group if they believe it is more appropriate.
 * Once the final amount spent is known, update the table again with that information.
 
 ### Reimbursement
-  
+
 Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc tracyhinds@linuxfoundation.org with subject `Node.js Member Travel Fund`. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. The community manager or a member of the Node.js Foundation team within the Linux Foundation will report back amounts consumed from the travel allocation on a monthly basis to the Chairs.
 
 **The following considerations are made for approval of the request:**
@@ -36,16 +37,31 @@ general knowledge about the foundation) there are people, communities and
 geographies where that knowledge is not very widespread. This is where
 preference will be given. For instance, an event in San Francisco would be
 less attractive than an event of the same size in Kansas City.
-* Cost: The larger the stipend the more critically the travel fund admins will 
+* Cost: The larger the stipend the more critically the travel fund admins will
 consider the application. Budget for this program is a finite resource.
 * Equity: Preference given to individuals who do not have a corporate travel fund and have
 not previously received a stipend.
 
-Examples of prior travel requests include attending a TC39 meeting, Collab Summit, and Code + Learn mentoring.
+Examples of prior travel requests include attending a TC39 meeting, Collaborators
+Summit, and Code + Learn mentoring.
 
 Name | Event | Kind of participation | Location | Date | Stipend size
 ---- | ----- | --------------------- | -------- | ---- | ------------
-Example Person | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 4 Oct – 7 Oct 2017 | US$ 2000
-  
+Rich Trott | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2000
+Anna Henningsen | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2530
+Stephen Belanger | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 800
+Italo A. Casas | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 644
+Anna Henningsen | TC39 Meeting | Attendance | San Jose, CA, US | 24 Jan – 26 Jan 2017 | US$ 1048
+Michaël Zasso | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 318
+Anna Henningsen | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 240
+Santiago Gimeno | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 160
+Calvin Metcalf | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 600
+Никита Сковорода | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | €573
+Bryan English | JSConf.cn 2017 | Code & Learn Mentor | Shanghai, CN | 15 July - 16 July 2017 | $1100
+Tobias Nießen | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 5 Oct - 8 Oct 2017 | €1300
+Tiancheng Gu | NINA 2017 | Collaborator Summit | Vancouver, BC, CA | 3 Oct – 8 Oct 2017 | US$ 1200
+Ruben Bridgewater | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 4 Oct - 8 Oct 2017 | €1500
+
+
 ## 2017 Board of Directors Allocation
-The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel funding for the remainder of 2017 was approved in the amount of $67,000. 
+The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel funding for the remainder of 2017 was approved in the amount of $67,000.

--- a/MEMBER_TRAVEL_FUND.MD
+++ b/MEMBER_TRAVEL_FUND.MD
@@ -1,0 +1,51 @@
+## Purpose
+
+To establish and administer a fund for members of the Node.js
+Foundation to travel and spread knowledge about and support the foundation
+and the Node.js Foundation projects.
+
+## Restrictions
+
+* Candidates must be an indvidual member of the Node.js Foundation.
+
+## Process
+
+Any member can apply for travel funds. Each request may take up to a month
+for the Admin members to approve or decline.
+
+### Request
+* Open a pull request against this repository which adds an entry to the table at the bottom of this file.
+ * Include the name of the event you plan to attend.
+ * Include the location of the event and where you will be traveling from.
+ * Include the presentation you intend to give, if applicable.
+ * Include the size of the stipend you wish to receive.
+  * Reimbursement stipends are expected to vary with travel distance.
+  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/commcomm-members. 
+  If unsure, just pick one, and that group will tag with the other group if they believe it is more appropriate.
+* Once the final amount spent is known, update the table again with that information.
+
+### Reimbursement
+  
+Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc tracyhinds@linuxfoundation.org with subject `Node.js Member Travel Fund`. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. The community manager or a member of the Node.js Foundation team within the Linux Foundation will report back amounts consumed from the travel allocation on a monthly basis to the Chairs.
+
+**The following considerations are made for approval of the request:**
+
+* Impact: Preference given to underserved communities. More specifically,
+within a subject the foundation is trying to promote awareness about (e.g.
+general knowledge about the foundation) there are people, communities and
+geographies where that knowledge is not very widespread. This is where
+preference will be given. For instance, an event in San Francisco would be
+less attractive than an event of the same size in Kansas City.
+* Cost: The larger the stipend the more critically the travel fund admins will 
+consider the application. Budget for this program is a finite resource.
+* Equity: Preference given to individuals who do not have a corporate travel fund and have
+not previously received a stipend.
+
+Examples of prior travel requests include attending a TC39 meeting, Collab Summit, and Code + Learn mentoring.
+
+Name | Event | Kind of participation | Location | Date | Stipend size
+---- | ----- | --------------------- | -------- | ---- | ------------
+Example Person | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 4 Oct – 7 Oct 2017 | US$ 2000
+  
+## 2017 Board of Directors Allocation
+The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel funding for the remainder of 2017 was approved in the amount of $67,000. 


### PR DESCRIPTION
To encourage as many collaborators to attend/represent at Node.js Collab Summit and other relevant events for the remainder of this year, the TSC and CommComm collaborated on a request for an increase in travel funding.  Per the Board's request, this fund is established in the Admin repo to be jointly administered by both groups.

This is a near copy/paste from the [TSC Travel Fund](https://github.com/nodejs/TSC/blob/master/Member-Travel-Fund.md) and the [CommComm PR for a travel fund](https://github.com/nodejs/community-committee/pull/81).

---------------
Once this PR is approved, the [TSC Travel Fund](https://github.com/nodejs/TSC/blob/master/Member-Travel-Fund.md) will be archived and members redirected to this document for future requests.

cc @nodejs/tsc @nodejs/community-committee 