### PR TITLE
chore: fix travel fund link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository is formal efforts of the Node.js project that are overseen and require input from both the [TSC](https://github.com/nodejs/TSC) and [CommComm](https://github.com/nodejs/community-committee).
 
 Initiatives that are overseen here:
-- [Travel Fund](https://github.com/nodejs/admin/blob/master/travel_fund.md)
+- [Travel Fund](https://github.com/nodejs/admin/blob/master/MEMBER_TRAVEL_FUND.MD)
 
 Repositories that fall under the responsibility of the TSC and CommComm:
 


### PR DESCRIPTION
link was not right