### PR TITLE
Defining Moderation Team member expectations

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -257,6 +257,9 @@ members must vote in *favor* of retaining an individual moderator.
 A simple majority vote of each the TSC and CommComm members is required to remove
 a moderator.
 
+Moderation team members have the same expections as other leadership groups
+as outlined [here](https://github.com/nodejs/admin/blob/master/MemberExpectations.md).
+
 Once per month, the Moderation Team must provide a report of all Moderation
 actions taken by the Moderation Team to both the CommComm and TSC.
 


### PR DESCRIPTION
The moderation team has agreed that team members should be held to the higher standards that apply to TSC & CommComm members.

I wasn't quite sure if I should also directly modify the [MemberExpectations.md](https://github.com/nodejs/admin/blob/master/MemberExpectations.md) as well to include the Moderation Team. I though this would be a good place to start with. 

Any feedback is appreciated.