### PR TITLE
Add Node Slack Community to scope

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -284,7 +284,9 @@ actions taken by the Moderation Team to both the CommComm and TSC.
 
 ### Admins for Node.js Slack community
 * [alextes](https://github.com/alextes) -
-**Alexander Tesfamichael** &lt; alex.tesfamichael@gmail.com&gt;
+**Alexander Tesfamichael** &lt;alex.tesfamichael@gmail.com&gt;
+* [aredridel](https://github.com/aredridel) -
+**Aria Stewart** &lt;aredridel@dinhe.net&gt;
 * [ljharb](https://github.com/ljharb) -
 **Jordan Harband** &lt;ljharb@gmail.com&gt;
 * [jxm262](https://github.com/jxm262) -

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -22,7 +22,9 @@ moderation request, please see [Requesting Moderation][]
 ## Applicability
 
 By default, this policy applies to all repositories under the Node.js GitHub
-Organization and all Node.js Working Groups.
+Organization and all Node.js Working Groups. This policy also applies to the
+[Node.js Slack Community](http://node-js.slack.com), supported by the Admin 
+team of the Slack organization.
 
 Individual Working Groups may adopt an alternative Moderation Policy for any
 repository under their stewardship so long as the Moderation Policy is

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -283,6 +283,8 @@ actions taken by the Moderation Team to both the CommComm and TSC.
 **Forrest L Norvell** &lt;othiym23@gmail.com&gt;
 
 ### Admins for Node.js Slack community
+* [alextes](https://github.com/alextes) -
+**Alexander Tesfamichael** &lt; alex.tesfamichael@gmail.com&gt;
 * [ljharb](https://github.com/ljharb) -
 **Jordan Harband** &lt;ljharb@gmail.com&gt;
 * [jxm262](https://github.com/jxm262) -

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -262,7 +262,7 @@ as outlined [here](https://github.com/nodejs/admin/blob/master/MemberExpectation
 Once per month, the Moderation Team must provide a report of all Moderation
 actions taken by the Moderation Team to both the CommComm and TSC.
 
-### Current Members
+### Current Members of Moderation Team
 * [refack](https://github.com/refack) -
 **Refael Ackermann** &lt;refack@gmail.com&gt;
 * [benjamingr](https://github.com/benjamingr) -
@@ -281,6 +281,14 @@ actions taken by the Moderation Team to both the CommComm and TSC.
 **Gibson Fahnestock** &lt;gibfahn@gmail.com&gt;
 * [othiym23](https://github.com/othiym23) -
 **Forrest L Norvell** &lt;othiym23@gmail.com&gt;
+
+### Admins for Node.js Slack community
+* [ljharb](https://github.com/ljharb) -
+**Jordan Harband** &lt;ljharb@gmail.com&gt;
+* [jxm262](https://github.com/jxm262) -
+**Justin Maat** &lt;jxm262@gmail.com&gt;
+* [hackygolucky](https://github.com/hackygolucky) -
+**Tracy Hinds** &lt;tracyhinds@gmail.com&gt;
 
 ## Escalation of Issues
 


### PR DESCRIPTION
Adds the Node.js Slack Community to the list of Moderation Team scope. Admins from the Slack community have agreed to posting and upholding the CoC and collaborating with the Moderation Team to uphold the guidelines. cc @alextes @ljharb

To note: would like to try this as well with `#nodejs` on Freenode IRC, but it takes a bit more work. So it stays listed in 'unofficial' on the Node.js community resources until/if we're able to confirm the same and have an admin team with bandwidth to support the existing community.

NOTE: DO NOT MERGE THIS UNTIL https://github.com/nodejs/getting-started/pull/10/files lands. Then link to it for anyone wanting further info on the group and finding it.