### PR TITLE
Fix incorrect link to Moderation Policy members

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -83,4 +83,4 @@ alias is copied to all members of the [Node.js Moderation Team][].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
-[Node.js Moderation Team]: https://github.com/nodejs/admin/blob/Moderation-Policy.md#current-members
+[Node.js Moderation Team]: https://github.com/nodejs/admin/blob/master/Moderation-Policy.md#current-members


### PR DESCRIPTION
The branch needed to be determined for the url to lead somewhere.

Stumbled upon this by aimlessly browing different nodejs repositories; figured I'd propose this fix 👍 