### PR TITLE
update the travel cost of @joyeecheung at the diagnostics summit

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -61,7 +61,7 @@ Bryan English | JSConf.cn 2017 | Code & Learn Mentor | Shanghai, CN | 15 July - 
 Tobias Nießen | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 5 Oct - 8 Oct 2017 | €1300
 Tiancheng Gu | NINA 2017 | Collaborator Summit | Vancouver, BC, CA | 3 Oct – 8 Oct 2017 | US$ 1200
 Ruben Bridgewater | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 4 Oct - 8 Oct 2017 | €1500
-Joyee Cheung | Diagnostics WG Summit | Attendance | Ottawa, ON, CA | 12 Feb - 13 Feb 2018 | US$ 1400
+Joyee Cheung | Diagnostics WG Summit | Attendance | Ottawa, ON, CA | 12 Feb - 13 Feb 2018 | US$ 1650
 
 ## 2017 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel funding for the remainder of 2017 was approved in the amount of $67,000.


### PR DESCRIPTION
I booked the flights a bit too late so the cost were ~200$ more than I estimated. I believe the travel fund works by allocating more than what actually gets reimbursed, and the received amount depends on the receipts sent to the foundation, so I allocate a bit more to account for exchange rate changes.

```
Hotel    506.66 CAD =  403.72 USD
Flight               1,202.17 USD
---------------------------------
                     1,605.89 USD
```

BTW: the document says we should cc `tracyhinds@linuxfoundation.org` in the reimbursement email but I think that's no longer true due to https://github.com/nodejs/board/issues/71 ...maybe @mrhinkle has a clue?