### PR TITLE
adjust governance text

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ The Admin repo is overseen by the [TSC](https://github.com/nodejs/TSC) and [Comm
 
 Members of the TSC and CommComm shall operate under Lazy Consensus as a collaborative unit in the Admin repo hereby referenced as the *Admin members*. Members shall establish appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the development process.
 
-The *Admin members* follow a Consensus Seeking decision making model. When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
-
-If an agenda item cannot reach a consensus a member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the *Admin members* or else the discussion will continue.
-
-For all votes, a simple majority of all *Admin members* for, or against, the issue wins. There must be a simple majority vote in each committee. If an individual happens to be in both committees, then they would end up with two votes. An *Admin member* may choose to participate in any vote through abstention.
+For all votes, the vote must pass in both TSC and CommComm or else the motion fails. If an individual happens to be in both committees, then they would end up with two votes.
 
 ### Contacts for assistance
 - [@ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams**, Individual Membership Director


### PR DESCRIPTION
@nodejs/tsc @nodejs/community-committee If we can get this through with Lazy Consensus, that would be awesome. Pile-on LGTMs from members of those committees welcome.

There is never an Admin meeting, so there is no Admin moderator or
agenda items. Remove that text as irrelevant. It was probably
copy/pasted from another doc.

The paragraph on votes seems to waver
between requiring a majority vote of all members vs. a majority vote on
both TSC and CommComm. Go with requiring the vote to pass on both
committees, as that is more stringent. (If it passes on both committees
with a majority, then there is also a majority overall. The reverse is
not necessarily true.) Next, remove the text about "simple majority" and
whatnot. CommComm and TSC should use whatever decision-making rules
around voting that they each have. That *may* be simple majority, but if
it is not, that's OK. It's also fine if CommComm and TSC have different
rules around votes. They should apply their own rules to their own
votes.