### PR TITLE
Add bias training offering

### DIFF
--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -49,7 +49,7 @@ we participate in official foundation work (GitHub, IRC, meetings,
 conferences), it is important to recognize that the public behavior
 of members also reflects on the Node.js project.
 
-If you're interested in an introduction to diversity inclusion, and unconscious bias, 
+If you're interested in an introduction to diversity, inclusion, and unconscious bias, 
 [try this free training offered by our partners at the Linux Foundation](https://training.linuxfoundation.org/linux-courses/open-source-compliance-courses/inclusive-speaker-orientation).
 
 If it appears that any member of the project leadership is acting outside

--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -50,7 +50,7 @@ conferences), it is important to recognize that the public behavior
 of members also reflects on the Node.js project.
 
 If you're interested in an introduction to diversity inclusion, and unconscious bias, 
-[Try this free training offered by our partners at the Linux Foundation](https://training.linuxfoundation.org/linux-courses/open-source-compliance-courses/inclusive-speaker-orientation).
+[try this free training offered by our partners at the Linux Foundation](https://training.linuxfoundation.org/linux-courses/open-source-compliance-courses/inclusive-speaker-orientation).
 
 If it appears that any member of the project leadership is acting outside
 of the expectations set above please refer to our

--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -49,6 +49,9 @@ we participate in official foundation work (GitHub, IRC, meetings,
 conferences), it is important to recognize that the public behavior
 of members also reflects on the Node.js project.
 
+If you're interested in an introduction to diversity inclusion, and unconscious bias, 
+[Try this free training offered by our partners at the Linux Foundation](https://training.linuxfoundation.org/linux-courses/open-source-compliance-courses/inclusive-speaker-orientation).
+
 If it appears that any member of the project leadership is acting outside
 of the expectations set above please refer to our
 [moderation](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md)


### PR DESCRIPTION
Adds bias training link for anyone interested in taking it, as it is a free offering available to anyone in the project courtesy of the LF. If there's a more appropriate place for this, please let me know. I've also added the training to the education repo, but thought that it would be good to surface it elsewhere in the project.