### PR TITLE
update process for travel requests

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -10,40 +10,72 @@ and the Node.js Foundation projects.
 
 ## Process
 
-Any member can apply for travel funds. Each request may take up to a month
-for the [Admin members](https://github.com/nodejs/admin#governance-and-current-members)
-to approve or decline.
+Any member can apply for travel funds.
 
 ### Request
-* Open a pull request against this repository which adds an entry to the table at the bottom of this file.
+
+* Open a pull request which adds an entry to the table at the bottom of this
+  file.
  * Include the name of the event you plan to attend.
  * Include the location of the event and where you will be traveling from.
  * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
-  * Reimbursement stipends are expected to vary with travel distance.
-  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/community-committee.  
-  If unsure, just pick one, and that group will tag with the other group if they believe it is more appropriate.
-* Once the final amount spent is known, update the table again with that information.
+   * Reimbursement stipends are expected to vary with travel distance.
+   * In the PR description, mention `@nodejs/tsc` and
+     `@nodejs/community-committee`.  
+* Once the final amount spent is known, update the table again with that
+  information.
 
-### Reimbursement
+### Approval
 
-Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc mrhinkle@linuxfoundation.org with subject `Node.js Member Travel Fund`. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. The community manager or a member of the Node.js Foundation team within the Linux Foundation will report back amounts consumed from the travel allocation on a monthly basis to the Chairs.
+A request is approved when all of the following criteria are met:
+
+* The pull request has been open for at least 72 hours.
+* The request has approval from at least two members of @nodejs/tsc and two
+  members of @nodejs/community-committee. (People who are members of both
+  committees may only be counted for one or the other. Therefore, any request
+  will always require at least four approvals.)
+* No members of either @nodejs/tsc or @nodejs/community-committee have objected
+  to the request.
+
+If a request is blocked by an objection from a member of @nodejs/tsc or
+@nodejs/community-committee, then the only way for the request to be approved is
+for that committee to decide to approve the request using whatever
+decision-making process the  committee uses when consensus is not reached. (For
+example, for the TSC, there is a voting process to make decisions when consensus
+cannot be reached.)
 
 **The following considerations are made for approval of the request:**
 
 * Impact: Preference given to underserved communities. More specifically,
 within a subject the foundation is trying to promote awareness about (e.g.
-general knowledge about the foundation) there are people, communities and
+general knowledge about the foundation) there are people, communities, and
 geographies where that knowledge is not very widespread. This is where
 preference will be given. For instance, an event in San Francisco would be
 less attractive than an event of the same size in Kansas City.
 * Cost: The larger the stipend the more critically the travel fund admins will
-consider the application. Budget for this program is a finite resource.
-* Equity: Preference given to individuals who do not have a corporate travel fund and have
-not previously received a stipend.
+consider the application. The budget for this program is a finite resource.
+* Equity: Preference given to individuals who do not have a corporate travel
+  fund and have not previously received a stipend.
 
-Examples of prior travel requests include attending a TC39 meeting, Collaborators
-Summit, and Code + Learn mentoring.
+Examples of prior travel requests include attending a TC39 meeting,
+Collaborator Summit, and Code + Learn mentoring.
+
+### Reimbursement
+
+Once the request has been approved, provide receipts as attachments in an email
+stating your name, the participation covered, and the total approved for
+reimbursement. Send to ap@linuxfoundation.org and cc
+mrhinkle@linuxfoundation.org with subject `Node.js Member Travel Fund`. Due to
+privacy, the Individual Members list is not public. This team will verify the
+requester is on the Individual Members list before funds are disbursed. This
+disbursement is generally processed within 30 days. The community manager or a
+member of the Node.js Foundation team within the Linux Foundation will report
+back amounts consumed from the travel allocation on a monthly basis to the
+Chairs.
+
+Once the final amount of reimbursement is known, update the table below with
+that information.
 
 Name | Event | Kind of participation | Location | Date | Stipend size
 ---- | ----- | --------------------- | -------- | ---- | ------------


### PR DESCRIPTION
We currently have somewhat of a problem with travel requests in that
there is no clear way to know when one is accepted. This was not a
problem when it was entirely up to the TSC, but now that this is jointly
administered by TSC and CommComm, many of the travel request PRs appear
stalled.

Here is my hopefully-uncontroversial proposal for unstalling. It would
be great to have pile-on LGTMs from both TSC and CommComm on this so we
can land it relatively quickly and get some resolution on the pending
travel requests.

@nodejs/tsc @nodejs/community-committee 