### PR TITLE
add @maddhruv to calendar maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The calendar is maintained by:
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@gibfahn](https://github.com/gibfahn) - **Gibson Fahnestock**
 - [@hackygolucky](https://github.com/hackygolucky) - **Tracy Hinds**
+- [@maddhruv][https://github.com/maddhruv] - **Dhruv Jain**
 - [@mcollina](https://github.com/mcollina) - **Matteo Collina**
 - [@mhdawson](https://github.com/mhdawson) - **Michael Dawson**
 - [@ryanmurakami](https://github.com/ryanmurakami) - **Ryan Lewis**


### PR DESCRIPTION
I shall be maintaining the @nodejs/badges and maybe @nodejs/website-redesign meeting events.
Reducing a much load from @bnb :stuck_out_tongue_winking_eye: 