### PR TITLE
update Member Expectations to include project stewardship

### DIFF
--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -9,16 +9,13 @@ contributors are expected to be respectful of these different viewpoints,
 and to work collaboratively with one another in a manner that constructively
 elevates all contributors.
 
-When an individual contributor chooses to accept an invitation to participate
-in a leadership role, they implicitly take on an additional obligation to protect
-and be respectful of both the project and all other contributors.  When
-decisions are made within the established guidelines and policies
-of the project, those in leadership roles have a responsibility to uphold
-and respect the decision even if they disagree with it. This is especially
-important in external communications, for example in social media. Should
-the member be unwilling or unable to do so, then they should
-resign their leadership position. This does not mean that decisions cannot
-be revisited and discussed within the team at a later time.
+When decisions are made within the established guidelines and policies of the
+project, those in leadership roles have a responsibility to uphold and respect
+the decision even if they disagree with it. This is especially important in
+external communications, for example in social media. Should the member be
+unwilling or unable to do so, then they should resign their leadership position.
+This does not mean that decisions cannot be revisited and discussed within the
+team at a later time.
 
 Members of our leadership groups must also conduct themselves in a
 professional and respectful manner. Some general guidelines include:


### PR DESCRIPTION
This change replaces text about leadership's obligation to "protect" the
project with a hopefully-more-clear reference to project stewardship.
The use of "protect" suggests a defensive and adversarial stance.
Project stewardship, on the other hand, implies more of a caretaker
stance. It still involves ensuring the project's well-being, but does
not assume that there is a fight to be had.

@nodejs/tsc @nodejs/community-committee 