### PR TITLE
bots need to be approved by CommComm and TSC per current policy

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -196,7 +196,7 @@ of the [Code of Conduct][].
   following the above procedures including: removing Posts, Blocking
   indefinitely, and reporting accounts to GitHub.
 * Accounts that are reasonably believed to be bots (other than bots authorized
-  by the TSC) are subject to immediate Blocking.
+  by both TSC and CommComm) are subject to immediate Blocking.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or
 escalation of inappropriate behavior by the individual whose post is being


### PR DESCRIPTION
@nodejs/tsc @nodejs/community-committee @nodejs/moderation 

A minor update to the Moderation Policy to bring it in line with our current GitHub policy. (Alternatively, we can change the GitHub policy so that only TSC needs to approve bots. I'm fine either way. Kind of depends on if CommComm wants to be able to block a bot or not.)