### PR TITLE
Add travel fund request to msbuild 2018 for chowdhurian

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -37,8 +37,8 @@ A request is approved when all of the following criteria are met:
   will always require at least four approvals.)
 * No members of either @nodejs/tsc or @nodejs/community-committee have objected
   to the request.
-* The pull request has been merged. Any member may merge once other 
-  prerequisites have been met. 
+* The pull request has been merged. Any member may merge once other
+  prerequisites have been met.
 
 If a request is blocked by an objection from a member of @nodejs/tsc or
 @nodejs/community-committee, then the only way for the request to be approved is
@@ -48,8 +48,8 @@ example, for the TSC, there is a voting process to make decisions when consensus
 cannot be reached.)
 
 An appointed treasurer from either the @nodejs/tsc or @nodejs/community-committee
-(or both) will liaise with a member of the Node.js Foundation on a regular basis 
-to review the status of the travel fund. In the event that any pending requests 
+(or both) will liaise with a member of the Node.js Foundation on a regular basis
+to review the status of the travel fund. In the event that any pending requests
 might not be approved because of available funds, a separate issue will be raised.
 Generally speaking, however, members shouldn't need to worry about the status
 of the fund itself.
@@ -72,7 +72,7 @@ Collaborator Summit, and Code + Learn mentoring.
 
 ### Reimbursement
 
-Once the request has been approved, you must: 
+Once the request has been approved, you must:
 
 1. Provide receipts as attachments in an email stating your name, the participation covered,
 and the total approved for reimbursement.
@@ -125,7 +125,7 @@ Agiri Abraham JNR | Collab Summit Spring 2018 | Attendance - Inclusivity Initiat
 Ujjwal Sharma | Collab Summit Spring 2018 | Attendance & Collaborate | Berlin, Germany | May 31-June 1 2018 | $1500
 Никита Сковорода | Collab Summit Spring 2018 | Attendance | Berlin, DE | May 30 - June 2 2018 | €735
 Nicola Del Gobbo | Collab Summit Spring 2018 | Attendance | Berlin, DE | May 30 - June 2 2018 | €400
-
+Manil Chowdhury | MSBuild 2018 | Microsoft <> Node.js Collaboration, CommComm Representation | Seattle, WA, USA | May 6 - May 10 2018 | USD 209.40
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.


### PR DESCRIPTION
## Description
Having read the comments in #139 regarding retroactive proposals, I understand that the process needs to be figured out. I'm adding this so that whichever way the issue is resolved, this PR is as well.

I'm ok with having paid out of pocket for travel and lodging! Thank you for the opportunity to represent Node.js and CommComm at MSBuild ❤️

**Event**: MSBuild 2018
**Event Location**: Seattle, WA, USA
**Traveling From**: Vancouver, BC, Canada
**Doing**: Representing Node.js and CommComm to Microsoft teams using Node.js
**Stipend Size**: USD 209.40
**Foundation member**: Confirmed to have membership order number
**Corporate travel fund**: None, confirmed

## Final amount for reimbursement
Item | Amount | Notes
---- | ------ | -----
Bus | $39.40 |
Accommodations | $140 |
Ancillary costs | $30 | insurance
**Total** | $209.40 |

## Groups represented
* Node.js
