### PR TITLE
Travel fund request for JS Interactive/Collab Summit 2018

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -130,6 +130,7 @@ Benjamin Zaslavsky | Collab Summit Spring 2018 | Attendance - Inclusivity Initia
 Ujjwal Sharma | Collab Summit Spring 2018 | Attendance & Collaborate | Berlin, Germany | May 29-June 3 2018 | $1384
 Nicola Del Gobbo | Collab Summit Spring 2018 | Attendance | Berlin, DE | May 30 - June 2 2018 | €400
 Manil Chowdhury | MSBuild 2018 | Microsoft <> Node.js Collaboration, CommComm Representation | Seattle, WA, USA | May 6 - May 10 2018 | USD 209.40
+Agiri Abraham Jnr | JS Interactive/Collab Summit | Attendance & Collaborate | Vancouver, BC, Cannada | Oct 10 - Oct 14 | USD 2250.00
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.


### PR DESCRIPTION
Event: JS Interactive + Collaborator Summit
Location: Vancouver BC CAN
Traveling from: Lagos, Nigeria

In addition to participating in Collaborator Summit.
@nodejs/community-committee

~Registration: $350~
Airline: $1800.00
Lodging: $480