### PR TITLE
github-team-discussion policy

### DIFF
--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -91,10 +91,13 @@ granted Owner permissions, of all actions taken.
 
 ## GitHub's Team Discussion <sup>[1][github-team-discussion]</sup>
 
-Eventough GitHub's Team Discussion are at the moment limited in visibility to members
-of the organization only, they should be considered as publicly visible. 
-Chartered sub-projects and working groups could decide to limit the visibility of these
-discussions, and then moderate and enforoce that by themselfs.
+The current implementation of GitHub's "Team Discussions" is incongrouent with the organization's policy.
+The maximal visibility of "public" threads is limited by GitHub to members of the org only, so they
+are not what the organization defines as public. Use of the "private" settings allows any team member
+to unilaterly create a thread that is visible only to members of that team, but this use is not
+covered by the organization's genral moderation policy.
+While the use of this feature is discurged, chartered sub-projects and working groups can decide
+to enact policy that spesifies the proper use of this feature, and then enforce that policy internaly.
 
 [github-team-discussion]: https://blog.github.com/2017-11-20-introducing-team-discussions/
 [nodejs/admin]: https://github.com/nodejs/admin

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -91,7 +91,7 @@ granted Owner permissions, of all actions taken.
 
 ## GitHub's Team Discussion <sup>[1][github-team-discussion]</sup>
 
-Since "Teams" represent the org's chartered sub-projects and working groups,
+Since Teams represent the org's chartered sub-projects and working groups,
 every such group can decide to define its own policy that specifies what they
 consider to be proper use of this feature and enforce that policy internally.
 

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -95,8 +95,8 @@ Since Teams represent the org's chartered sub-projects and working groups,
 every such group can decide to define its own policy that specifies what they
 consider to be proper use of this feature and enforce that policy internally.
 
-*For General consideration*: The current implementation of GitHub's "Team
-Discussions" is incongruent with the organization's policy. The maximal
+*For General consideration*: The current implementation of GitHub's Team
+Discussions is incongruent with the organization's policy. The maximal
 visibility of "public" threads is limited by GitHub to members of the org only,
 so they are not what the organization defines as public. Use of the "private"
 settings allows any team member to create a thread that is visible only to members

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -89,4 +89,12 @@ Bots that perform actions on behalf of the project (such as moderation or member
 management actions) are required to maintain a log, accessible to all individuals
 granted Owner permissions, of all actions taken.
 
+## GitHub's Team Discussion <sup>[1][github-team-discussion]</sup>
+
+Eventough GitHub's Team Discussion are at the moment limited in visibility to members
+of the organization only, they should be considered as publicly visible. 
+Chartered sub-projects and working groups could decide to limit the visibility of these
+discussions, and then moderate and enforoce that by themselfs.
+
+[github-team-discussion]: https://blog.github.com/2017-11-20-introducing-team-discussions/
 [nodejs/admin]: https://github.com/nodejs/admin

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -91,16 +91,18 @@ granted Owner permissions, of all actions taken.
 
 ## GitHub's Team Discussion <sup>[1][github-team-discussion]</sup>
 
-The current implementation of GitHub's "Team Discussions" is incongruent with
-the organization's policy. The maximal visibility of "public" threads is
-limited by GitHub to members of the org only, so they are not what the
-organization defines as public. Use of the "private" settings allows any team
-member to unilaterally create a thread that is visible only to members of that
-team, but this use is not covered by the organization's general moderation
-policy.  
-While the use of this feature is discouraged, chartered sub-projects and working
-groups can decide to enact policy that specifies the proper use of this feature,
-and then enforce that policy internally.
+Since "Teams" represent the org's chartered sub-projects and working groups,
+every such group can decide to define its own policy that specifies what they
+consider to be proper use of this feature and enforce that policy internally.
+
+*For General consideration*: The current implementation of GitHub's "Team
+Discussions" is incongruent with the organization's policy. The maximal
+visibility of "public" threads is limited by GitHub to members of the org only,
+so they are not what the organization defines as public. Use of the "private"
+settings allows any team member to create a thread that is visible only to members
+of that team, under the assumtion that it is private, but such use is not covered
+by the organization's general moderation policy.  
+
 
 [github-team-discussion]: https://blog.github.com/2017-11-20-introducing-team-discussions/
 [nodejs/admin]: https://github.com/nodejs/admin

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -91,13 +91,16 @@ granted Owner permissions, of all actions taken.
 
 ## GitHub's Team Discussion <sup>[1][github-team-discussion]</sup>
 
-The current implementation of GitHub's "Team Discussions" is incongrouent with the organization's policy.
-The maximal visibility of "public" threads is limited by GitHub to members of the org only, so they
-are not what the organization defines as public. Use of the "private" settings allows any team member
-to unilaterly create a thread that is visible only to members of that team, but this use is not
-covered by the organization's genral moderation policy.
-While the use of this feature is discurged, chartered sub-projects and working groups can decide
-to enact policy that spesifies the proper use of this feature, and then enforce that policy internaly.
+The current implementation of GitHub's "Team Discussions" is incongruent with
+the organization's policy. The maximal visibility of "public" threads is
+limited by GitHub to members of the org only, so they are not what the
+organization defines as public. Use of the "private" settings allows any team
+member to unilaterally create a thread that is visible only to members of that
+team, but this use is not covered by the organization's general moderation
+policy.  
+While the use of this feature is discouraged, chartered sub-projects and working
+groups can decide to enact policy that specifies the proper use of this feature,
+and then enforce that policy internally.
 
 [github-team-discussion]: https://blog.github.com/2017-11-20-introducing-team-discussions/
 [nodejs/admin]: https://github.com/nodejs/admin

--- a/GITHUB_ORG_MANGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANGEMENT_POLICY.md
@@ -100,7 +100,7 @@ Discussions" is incongruent with the organization's policy. The maximal
 visibility of "public" threads is limited by GitHub to members of the org only,
 so they are not what the organization defines as public. Use of the "private"
 settings allows any team member to create a thread that is visible only to members
-of that team, under the assumtion that it is private, but such use is not covered
+of that team, under the assumption that it is private, but such use is not covered
 by the organization's general moderation policy.  
 
 


### PR DESCRIPTION
An alternative to https://github.com/nodejs/admin/pull/121
For approval by the @nodejs/tsc and @nodejs/community-committee 

As discussed in the 2018-06-14 meeting of the Community Committee, we recommend considering "Team Discussions" as public, and setting that as the default organizational policy. If chartered sub projects or working groups want to set their own rules, it will be their responsibility to enforce those rules and moderate those discussions.