### PR TITLE
allow hiding of comments (Moderation Policy udpate)

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -197,6 +197,8 @@ of the [Code of Conduct][].
   indefinitely, and reporting accounts to GitHub.
 * Accounts that are reasonably believed to be bots (other than bots authorized
   by both TSC and CommComm) are subject to immediate Blocking.
+* Collaborators have broad authority to use the Hide feature in the GitHub
+  interface for blatantly off-topic posts by non-Collaborators.
 
 ### Temporary Interaction Limits
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -197,8 +197,8 @@ of the [Code of Conduct][].
   indefinitely, and reporting accounts to GitHub.
 * Accounts that are reasonably believed to be bots (other than bots authorized
   by both TSC and CommComm) are subject to immediate Blocking.
-* Collaborators have broad authority to use the Hide feature in the GitHub
-  interface for blatantly off-topic posts by non-Collaborators.
+* Collaborators may use the Hide feature in the GitHub interface for off-topic
+  posts by non-Collaborators.
 
 ### Temporary Interaction Limits
 


### PR DESCRIPTION
Allow Collaborators to use the GitHub "Hide" feature for
off-topic comments from non-Collaborators.

Refs: https://github.com/nodejs/moderation/issues/214