### PR TITLE
Update Travel Fund for JS Interactive

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -137,7 +137,7 @@ Manil Chowdhury | MSBuild 2018 | Microsoft <> Node.js Collaboration, CommComm Re
 Gus Caplan | TC39 Meeting | Attendance | Redmond, WA, US | 23 July – 27 July 2018 | US $1,112.28
 Rich Trott | Collab Summit & JS Interactive 2018 | Facilitate Code & Learn | Vancouver BC CAN | Oct 10 -13 2018 | US$850
 Guy Bedford | Collab Summit 2018 | Attendance & Collaboration | Vancouver, BC, CA | 12 - 13 Oct 2018 | US$1875
-Agiri Abraham Jnr | JS Interactive/Collab Summit | Attendance & Collaborate | Vancouver, BC, Cannada | Oct 10 - Oct 14 | USD 2250.00
+Agiri Abraham Jnr | JS Interactive/Collab Summit | Attendance & Collaborate | Vancouver, BC, Cannada | Oct 10 - Oct 14 | USD 2645.00
 Dhruv Jain | Node Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC, CAN | Oct 10 - 13 2018 | $2100
 Никита Сковорода | Collab Summit 2018 | Attendance & Collaboration | Vancouver, BC, CA | 12 - 13 Oct 2018 | US$1500
 Hassan Yabagi Sani | Collab Summit & JS Interactive 2018 | Code and Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2376


### PR DESCRIPTION
Event: JS Interactive + Collaborator Summit
Location: Vancouver BC CAN
Traveling from: Lagos, Nigeria

I plan to attend Collaborator Summit and Code + Learn. In addition to participating in Collaborator Summit.

@nodejs/community-committee

Airline : $1900
Lodging: $600
Visa: $145