### PR TITLE
Fix the link to visa request instructions

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -19,7 +19,7 @@ issued. It is strongly recommended that you submit your request far enough in
 advance to get approval before making relevant expenditures.
 
 If you need a visa for the country in which the Node.js event you are attending
-is being held, see the document titled [`travel-visas.md`][travel-visas].
+is being held, see the detail instructions on [how to prepare for visa application](./travel-visas.md).
 
 ### Request
 
@@ -147,5 +147,3 @@ Patricia Realini | Node Summit | Panel Speaker | San Francisco, CA, USA | July 2
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.
-
-[travel-visas]: https://github.com/nodejs/admin/travel-visas.md "travel visas document"

--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -19,7 +19,7 @@ issued. It is strongly recommended that you submit your request far enough in
 advance to get approval before making relevant expenditures.
 
 If you need a visa for the country in which the Node.js event you are attending
-is being held, see the detail instructions on [how to prepare for visa application](./travel-visas.md).
+is being held, see the document on [preparing for a visa application](./travel-visas.md).
 
 ### Request
 


### PR DESCRIPTION
With minor tweaks to the text to make it more obvious. Folks aren't looking for a file, they are looking for information which happens to be contained in a file.