### PR TITLE
Travel funds request for addaleax @ JS Interactive

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -143,6 +143,7 @@ Dhruv Jain | Node Collab Summit & JS Interactive 2018 | Attendance, Collaborate 
 Hassan Yabagi Sani | Collab Summit & JS Interactive 2018 | Code and Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2376
 Ahmad Bamieh | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2250
 Patricia Realini | Node Summit | Panel Speaker | San Francisco, CA, USA | July 23-25 2018 | USD$1150
+Anna Henningsen | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$1360
 
 
 ## 2018 Board of Directors Allocation


### PR DESCRIPTION
This decomposes as 330 € for lodging, and 830 € for flights, which is currently equivalent to about 1360 USD.

I’m sorry this wasn’t announced as part of the survey, as I had been under the impression that there was separate funding for Code & Learn leads like last year (there is not).