### PR TITLE
Update Moderator List

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -282,8 +282,6 @@ through the full approval process in order to become a Moderation Team member ag
 <!-- referenced from the CoC page -->
 <a id="current-members"></a>
 ### Current Members of Moderation Team
-* [refack](https://github.com/refack) -
-**Refael Ackermann** &lt;refack@gmail.com&gt;
 * [benjamingr](https://github.com/benjamingr) -
 **Benjamin Gruenbaum** &lt;benjamingr@gmail.com&gt;
 * [ryanmurakami](https://github.com/ryanmurakami) -


### PR DESCRIPTION
As refack has stepped down as a moderator a while back and we've updated the other list - it makes sense to keep this one updated.

As this is an administrative change to sync up this list with the one in the private moderation repo - I'm going to go ahead and land it directly. If anyone feels strongly against this please do feel free to speak up and suggest a revert. This is per our policy for stepping down from https://github.com/nodejs/admin/blob/master/Moderation-Policy.md

cc @nodejs/moderation 