### PR TITLE
Travel stipend request for @lirantal attending JS Interactive and Collaborator Summit in Vancouver

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -169,6 +169,7 @@ Alejandro Oviedo | Collab Summit & JS Interactive 2018 | Attendance & Collaborat
 Anna Henningsen | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$1360
 Ujjwal Sharma | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vacouver BC, CAN | Oct 9 - Oct 14 | $2500
 Jamie Davis | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver BC, CAN | Oct 9 - Oct 14 | US$1175
+Liran Tal | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver BC, CAN | Oct 9 - Oct 14 | US$550
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.


### PR DESCRIPTION
Hi,

I will be a panel speaker at the JS Interactive conference in October and have received some funding from them ($1500 USD) but will require more to cover the costs to also attend the Node.js Collaborator summit.

I currently estimate the further amount to be:
Airbnb accommodation: $440 (~110$ per night + taxes)
Transportation: $100
Visa: $10
**Total: $550**

cc: @nodejs/tsc  @nodejs/community-committee