### PR TITLE
Travel Fund Request for JS Interactive

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -169,6 +169,7 @@ Alejandro Oviedo | Collab Summit & JS Interactive 2018 | Attendance & Collaborat
 Anna Henningsen | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$1360
 Ujjwal Sharma | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vacouver BC, CAN | Oct 9 - Oct 14 | $2500
 Jamie Davis | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver BC, CAN | Oct 9 - Oct 14 | US$1175
+Rachel White | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver BC, CAN | Oct 9 - Oct 14 | US $2439.86
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.


### PR DESCRIPTION
Event: JS Interactive + Collaborator Summit
Dates: Oct 10-13 2018
Location: Vancouver BC, Canada
Traveling from: NYC, NY, USA

@nodejs/tsc @nodejs/community-committee

Flight: $489.86	
JSInteractive ticket: $350
Lodging: ~$1600

Total: $2439.86