### PR TITLE
Update for JS Interactive tickets

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -162,7 +162,7 @@ Guy Bedford | Collab Summit 2018 | Attendance & Collaboration | Vancouver, BC, C
 Agiri Abraham Jnr | JS Interactive/Collab Summit | Attendance & Collaborate | Vancouver, BC, Cannada | Oct 10 - Oct 14 | USD 2645.00
 Dhruv Jain | Node Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC, CAN | Oct 10 - 13 2018 | $2100
 Никита Сковорода | Collab Summit 2018 | Attendance & Collaboration | Vancouver, BC, CA | 12 - 13 Oct 2018 | US$1500
-Hassan Yabagi Sani | Collab Summit & JS Interactive 2018 | Code and Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2376
+Hassan Yabagi Sani | Collab Summit & JS Interactive 2018 | Code and Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2741
 Ahmad Bamieh | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$2250
 Patricia Realini | Node Summit | Panel Speaker | San Francisco, CA, USA | July 23-25 2018 | USD$1150
 Alejandro Oviedo | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver, BC, Canada | Oct 10 - Oct 14 | USD 2200


### PR DESCRIPTION
**Update**: Received a mail from @joyeecheung on Sponsoring tickets for JS Interactive updated with the ticket fees for total funds.

@nodejs/community-committee 

Airline : $1900
Lodging: $400
JS Interactive Tickets: $365
Visa: $76