### PR TITLE
doc: add travel fund

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -174,6 +174,7 @@ Adam Miller | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | V
 Trivikram Kamat | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver BC CAN |  Oct 10 - 13 2018 | US$1000
 Tobias Nießen | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver, BC, CAN | Oct 9 - Oct 14 2018 | US$2100
 Liran Tal | Collab Summit & JS Interactive 2018 | Attendance & Collaborate | Vancouver BC, CAN | Oct 9 - Oct 14 | US$550
+Ruben Bridgewater | Collab Summit & JS Interactive 2018 | Attendance, Collaborate and Code & Learn | Vancouver, BC, CAN | Oct 9 - Oct 14 2018 | US$2150
 
 ## 2018 Board of Directors Allocation
 The coordinated request from the Technical Steering Committee and the Community Committee for the joint travel fund for 2018 was approved in the amount of $60,000.


### PR DESCRIPTION
**Event**: JS Interactive and Collaborator Summit
**Location**: Vancouver, British Columbia, Canada
**Travelling from**: Frankfurt, Germany

This is the estimate with the current prices:

* Transportation (airfare + train): USD 700
* Loding: USD 1100
* Conference Ticket: USD 350

Corporate fund is sadly not available due to a recent policy change and a strict limit for travelling funds. This came to my attention just two days ago (earlier it seemed that everything would be taken care of). Therefore I was also not able to get a early bird ticket for the conference.

cc @nodejs/tsc @nodejs/community-committee