### PR TITLE
Node+JSI travel fund sponsorship request for @dshaw

### DIFF
--- a/TravelFunds/2018.md
+++ b/TravelFunds/2018.md
@@ -45,4 +45,4 @@ Trivikram	|	Kamat	|	JS Interactive and Collaborator Summit	|	Attendance, Collabo
 Waleed	|	Ashraf	|	JS Interactive and Collaborator Summit	|	Attendance, Collaborate and Code & Learn	|	Vancouver BC, Canada	|	9Oct - 14Oct 2018	|	US$2400	|	20Sep 2018	|	|		|		|		|		|	
 Saleh	|	Abdel Motaal	|	JS Interactive and Collaborator Summit	|	Attendance, Collaborate and Code & Learn	|	Vancouver BC, Canada	|	10Oct -14Oct 2018	|	US$1700	| 19Sep 2018 | https://github.com/nodejs/admin/pull/232 | | | | |	
 Anatoli	|	Papirovski	|	JS Interactive and Collaborator Summit	|	Attendance, Collaborate and Code & Learn	|	Vancouver BC, Canada	|	9Oct - 13Oct 2018	|	US$1633.53	|	26Sep 2018	|	https://github.com/nodejs/admin/pull/235 |		|		|		|		|	
-
+Dan | Shaw | JS Interactive and Collaborator Summit | Attendance, Collaborate and Code & Learn | Vancouver, BC, CAN | 9oct - 14oct 2018 | US$1820 | | https://github.com/nodejs/admin/pull/224 | | | | |


### PR DESCRIPTION
Event: Node+JS Interactive + Node.js Collaborator Summit
Location: Vancouver BC, Canada
Traveling from: San Francisco, CA

|  | Cost  |
|------|-----|
| Flight | $520 |
| Lodging | $1300 |
| **Total** | **$1820** |

I am an individual member of Node.js Foundation.
Corporate funding is not available.

@nodejs/tsc @nodejs/community-committee