### PR TITLE
Update travel fund request for @ChALkeR

### DIFF
--- a/TravelFunds/2018.md
+++ b/TravelFunds/2018.md
@@ -27,7 +27,7 @@ Ben	|	Michel	|	Node.js at MSBuild 2018	|	Node.js Collaboration & CommComm Repres
 Nicola	|	Del Gobbo	|	Collab Summit Spring 2018	|	Attendance	|	Berlin, Germany	|	30May - 2Jun 2018	|	US$534.47	|		|		|		|		|		|		|	
 Gus	|	Caplan	|	TC39 Meeting	|	Attendance	|	Redmond, WA, US	|	 23Jul –  Jul27 2018	|	US$1112.28	|		|		|		|		|		|		|	
 Dhruv	|	Jain	|	Node Collab Summit & JS Interactive 2018	|	Attendance, Collaborate and Code & Learn	|	Vancouver BC, CAN	|	10Oct - 13Oct 2018	|	US$2100	|		|		|		|		|		|		|	
-Никита	|	Сковорода	|	Collab Summit 2018	|	Attendance & Collaboration	|	Vancouver BC, CAN	|	12Oct - 13Oct 2018	|	US$1500	|		|		|		|		|		|		|	
+Никита	|	Сковорода	|	Collab Summit 2018	|	Attendance & Collaboration	|	Vancouver BC, CAN	|	12Oct - 13Oct 2018	|	US$1660	|		|		|		|		|		|		|	
 Hassan Yabagi Sani	|		|	Collab Summit & JS Interactive 2018	|	Code and Learn	|	Vancouver BC, CAN	|	10Oct - 13Oct 2018	|	US$2376	|		|		|		|	US$2741	|		|		|	US$2741
 Ahmad	|	Bamieh	|	Collab Summit & JS Interactive 2018	|	Attendance, Collaborate and Code & Learn	|	Vancouver BC, CAN	|	10Oct - 13Oct 2018	|	US$2250	|		|		|		|		|		|		|	
 Patricia	|	Realini	|	Node Summit	|	Panel Speaker	|	San Francisco, CA, USA	|	23Jul - 25Jul 2018	|	US$1150	|		|		|		|		|		|		|	


### PR DESCRIPTION
This increases the requested amount from $1500 to $1660, mostly due to unaccaunted (at first) lodging taxes and visa costs being larger then anticipated (needed to legally translate some documents).

Travel: ~$910
Visa costs: ~$210
Lodging: ~$540

This is not the final amount yet, that would be available after the event is over, but the final amount is expected to be lower than this (most likely approximately equal, as most of this is finalized).

This is a ~$10 increase for travel, ~$60 increase for visa costs, and ~$90 increase for lodging costs over the previosly approved amount.

Refs: https://github.com/nodejs/admin/pull/165

Dates: 12 - 13 Oct 2018

On the bright side — I've now got an entry visa valid for ~5 years, so I won't need one next time. :tada:

Sorry for filing this update so late and close to the event, I just accounted that today.
I would understand if this increase would be deemed out of the timeslot and rejected. That would not stop me from coming to the event.