### PR TITLE
expand scope of `moderate` to include threads. Allow for locking

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -52,11 +52,10 @@ this default policy applies.
   more information.
 * *TSC* refers to the [Node.js Technical Steering Committee][].
 * *CommComm* refers to the [Node.js Community Committee][].
-* *Post* refers to the content and titles of any issue, pull request, comment
+* *Post* refers to the content and titles of any issue, pull request, comment,
   or wiki page.
-* *Moderate* refers to the act of modifying the content and title of, locking, or
-  deleting, any Post or thread for the purpose of correcting or addressing Code
-  of Conduct violations.
+* *Moderate* means to modify, lock, or delete one or more Posts to correct or
+  address Code of Conduct violations.
 * *Remove* refers to the act of removing the configured write (commit)
   permissions for an individual Collaborator's GitHub account from *all*
   Node.js GitHub Organization repositories as well as removing the account from

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -55,7 +55,7 @@ this default policy applies.
 * *Post* refers to the content and titles of any issue, pull request, comment
   or wiki page.
 * *Moderate* refers to the act of modifying the content and title of, locking or
-  deleting, any Post for the purpose of correcting or addressing Code
+  deleting, any Post or thread for the purpose of correcting or addressing Code
   of Conduct violations.
 * *Remove* refers to the act of removing the configured write (commit)
   permissions for an individual Collaborator's GitHub account from *all*

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -54,7 +54,7 @@ this default policy applies.
 * *CommComm* refers to the [Node.js Community Committee][].
 * *Post* refers to the content and titles of any issue, pull request, comment
   or wiki page.
-* *Moderate* refers to the act of modifying the content and title of, locking or
+* *Moderate* refers to the act of modifying the content and title of, locking, or
   deleting, any Post or thread for the purpose of correcting or addressing Code
   of Conduct violations.
 * *Remove* refers to the act of removing the configured write (commit)

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -54,9 +54,9 @@ this default policy applies.
 * *CommComm* refers to the [Node.js Community Committee][].
 * *Post* refers to the content and titles of any issue, pull request, comment
   or wiki page.
-* *Moderate* refers to the act of modifying the content and title of, or
-  deleting, any Post for the purpose of correcting or addressing Code of Conduct
-  violations.
+* *Moderate* refers to the act of modifying the content and title of, locking or
+  deleting, any Post for the purpose of correcting or addressing Code
+  of Conduct violations.
 * *Remove* refers to the act of removing the configured write (commit)
   permissions for an individual Collaborator's GitHub account from *all*
   Node.js GitHub Organization repositories as well as removing the account from
@@ -194,6 +194,7 @@ of the [Code of Conduct][].
 * One may immediately bypass the above procedures if it is clear that there is no intention to
   collaborate in good faith. In such cases, it is permissible to immediately:
   * remove posts
+  * lock issues/pull requests
   * delete issues/pull requests
   * block users
   * report accounts to GitHub


### PR DESCRIPTION
8e05be9 (Myles Borins, 50 seconds ago)
   moderation: expand scope to threads

   The current definition of moderation is scoped to a specific post not and
   entire thread

a66c539 (Myles Borins, 2 minutes ago)
   moderation: be explicit about locking

   Moderation didn't currently cover the scope of locking a thread.