### PR TITLE
Add Ahmad Bamieh to calendar maintainers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ https://nodejs.org/calendar
 The calendar is maintained by:
 <!-- sorted by GitHub handle -->
 - [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**
+- [@bamieh](https://github.com/bamieh) - **Ahmad Bamieh**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@dshaw](https://github.com/dshaw) - **Dan Shaw**
 - [@gibfahn](https://github.com/gibfahn) - **Gibson Fahnestock**


### PR DESCRIPTION
Ahmad reached out to me because they're having trouble maintaining the Mentorship calendar invite via other people – the team actually missed someone they were relying on today because the calendar wasn't correct.

Adding them to the team so they can manage the Mentorship invites as appropriate.