### PR TITLE
fix broken link to GitHub-Org-Management-Policy

### DIFF
--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -56,6 +56,6 @@ npm account.
 
 [coc]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [GitHub's documentation on transferring repos]: https://help.github.com/articles/about-repository-transfers/
-[Node.js GitHub Organization Management Policy]: https://github.com/nodejs/TSC/blob/master/GitHub-Org-Management-Policy.md#repositories
+[Node.js GitHub Organization Management Policy]: https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANGEMENT_POLICY.md#repositories
 [the contributing guide]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 [the issue tracker of the Node.js admin repository]: https://github.com/nodejs/admin/issues


### PR DESCRIPTION
Hello,
the actual [link](https://github.com/nodejs/TSC/blob/master/GitHub-Org-Management-Policy.md#repositories) return 404.

I searched for the file in Node.js org and found the new one that should be the same