### PR TITLE
update travel fund policy

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -13,7 +13,7 @@ ecosystem and the Foundation.
 
 * Candidates must be an individual member of the Node.js Foundation. [The membership status can be checked on the foundation website](https://identity.linuxfoundation.org/user/login?destination=user/me). Due to privacy, the Individual Members list is not public. 
 This team will verify the requester is on the Individual Members list before funds are disbursed.
-  * Exception: For the Collaborator Summits, members of JavaScript Foundation
+  * Exception: For the Collaborator Summits, members of JS Foundation
     projects may submit funding requests.
 * Those requesting funds must indicate that they do not have funding available from another source, such as an employer or 
 the event itself that might cover costs for presenters.

--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -12,9 +12,11 @@ ecosystem and the Foundation.
 ## Requirements
 
 * Candidates must be an individual member of the Node.js Foundation. [The membership status can be checked on the foundation website](https://identity.linuxfoundation.org/user/login?destination=user/me). Due to privacy, the Individual Members list is not public. 
-This team will verify the requester is on the Individual Members list before funds are disbursed. 
+This team will verify the requester is on the Individual Members list before funds are disbursed.
+  * Exception: For the Collaborator Summits, members of JavaScript Foundation
+    projects may submit funding requests.
 * Those requesting funds must indicate that they do not have funding available from another source, such as an employer or 
-the event itself that might cover costs for presenters. 
+the event itself that might cover costs for presenters.
 
 ## Process
 


### PR DESCRIPTION
Explicitly permit JS Foundation projects to request travel funds for
Collaborator Summits.

Refs: https://github.com/nodejs/admin/pull/361#issuecomment-490957214

@nodejs/tsc @nodejs/community-committee I'd like to get this fast-tracked so that I can approve https://github.com/nodejs/admin/pull/361 in good conscience. Some overwhelming fast approvals on this would be appreciated.