### PR TITLE
Update the logistics of filing expenses

### DIFF
--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -119,11 +119,35 @@ previously received a stipend.
 
 ## Reimbursement
 
-Once the request has been approved, you must email travelapprovals@nodejs.org with following information:
+So that we can reimburse you more quickly, we strongly encourage you to use
+[Expensify](https://expensify.com) to organize and submit your receipts.  Please
+see our [guide to creating and configuring a free Expensify
+account](./reimbursement_process.pdf).
 
-1. Provide receipts as attachments stating your name, the participation covered and the total approved for reimbursement.
-2. Fill out and attach the [Expense Report](./expense-report-template.xls?raw=true) and rename as ExpenseReport-Node-EVENTNAME-YOURNAME-YYYYMM.
-3. Sign the form, date the form, and return it as a PDF. The sign line can be found in the lower left hand corner of the above document. The individual tasked with approving the expense will countersign before sending for processing. You may use an e-signature such as docusign or [the 'markup' feature in Preview](https://support.apple.com/guide/preview/fill-out-and-sign-pdf-forms-prvw35725/mac).
+Here are the highlights of the process:
+
+* A free Expensify account is sufficient.
+* You can use the Android and iOS apps to capture receipts while you are
+  traveling.  If you do not use the app, you will need to upload photos of your
+  receipts after you return.
+* When you add an expense, please use local currency so that it matches the
+  amount on the receipt.
+* Once you have uploaded your receipts, please add them to a report and submit
+  it with [operations@openjsf.org](mailto:operations@openjsf.org) on cc, and the
+  Memo field set to "YOURNAME - TRIPNAME".
+
+When we receive your report, we will send you a form via DocuSign to collect
+your payment details.  At that point, you're done.
+
+### Alternate process
+
+If you decide not to use Expensify, the reimbursement process is manual and may
+take longer for us to process.  You can email a zip file of your receipts and
+the completed [Expense Report](./expense-report-template.xls?raw=true), renamed
+as ExpenseReport-OpenJS-EVENTNAME-YOURNAME-YYYYMM.xls, to
+[operations@openjsf.org](mailto:operations@openjsf.org).  Please send the file
+as a spreadsheet, not as a PDF.  We will send it back to you for signature in
+DocuSign.
 
 ### Important:
 

--- a/MEMBER_TRAVEL_FUND.md
+++ b/MEMBER_TRAVEL_FUND.md
@@ -126,7 +126,7 @@ account](./reimbursement_process.pdf).
 
 Here are the highlights of the process:
 
-* A free Expensify account is sufficient.
+* A free [Expensify](https://www.expensify.com/) account is sufficient.
 * You can use the Android and iOS apps to capture receipts while you are
   traveling.  If you do not use the app, you will need to upload photos of your
   receipts after you return.

--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -3,7 +3,7 @@
 First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates | Amount Requested: | Pull Request date | Pull Request link | Date Expense report sent | Amount of Expense Report | Date Sent to Finance | Date approved through Bill.com | Bill.com Amount approved for reimbursement
 -|-|-|-|-|-|-|-|-|-|-|-|-|-|-
 Anna | Henningsen | Diagnostics WG Summit | Attendance | N/A | Munich |6 Mar – 9 Mar 2019 | 252.68 € | 21 Jan 2019 | https://github.com/nodejs/admin/pull/295 ||$288.56|22 Mar 2019||$288.56
-Rich | Trott | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | US $1404.12 | 8 Mar 2019 | https://github.com/nodejs/admin/pull/309 |||||
+Rich | Trott | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | US $1404.12 | 8 Mar 2019 | https://github.com/nodejs/admin/pull/309 ||$1,404.12|2 Jul 2019||
 Guy | Bedford | Collaborator Summit | Attendance || Berlin |30 May - 31 May 2019 | $1185 USD | 13 March 2019 |||$1,185.16|20 Jun 2019|23 Jun 2019| $1,185.16
 Anto | Aravinth | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | 1300 USD | 21 March 2019 |||$1,027.77|20 Jun 2019|23 Jun 2019 | $1,027.77
 Ruben | Bridgewater | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | 650 € | 28 March 2019 | https://github.com/nodejs/admin/pull/322 |||||

--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -3,7 +3,7 @@
 First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates | Amount Requested: | Pull Request date | Pull Request link | Date Expense report sent | Amount of Expense Report | Date Sent to Finance | Date approved through Bill.com | Bill.com Amount approved for reimbursement
 -|-|-|-|-|-|-|-|-|-|-|-|-|-|-
 Anna | Henningsen | Diagnostics WG Summit | Attendance | N/A | Munich |6 Mar – 9 Mar 2019 | 252.68 € | 21 Jan 2019 | https://github.com/nodejs/admin/pull/295 ||$288.56|22 Mar 2019||$288.56
-Rich | Trott | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | US $1404.12 | 8 Mar 2019 | https://github.com/nodejs/admin/pull/309 ||$1,404.12|2 Jul 2019||
+Rich | Trott | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | US $1404.12 | 8 Mar 2019 | https://github.com/nodejs/admin/pull/309 |||||
 Guy | Bedford | Collaborator Summit | Attendance || Berlin |30 May - 31 May 2019 | $1185 USD | 13 March 2019 |||$1,185.16|20 Jun 2019|23 Jun 2019| $1,185.16
 Anto | Aravinth | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | 1300 USD | 21 March 2019 |||$1,027.77|20 Jun 2019|23 Jun 2019 | $1,027.77
 Ruben | Bridgewater | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | 650 € | 28 March 2019 | https://github.com/nodejs/admin/pull/322 |||||


### PR DESCRIPTION
As mentioned in issue #379, I'd like to propose some updates to the
reimbursement process to make it faster and less error-prone.  This was tested
in a limited way during the last cycle, and it worked well.

At a high level, this provides a new option for submitting expenses that doesn't
require spreadsheets or a zip file of receipts (although it's still available if
someone really wants to use it).  Rather, it encourages people to use a free
Expensify account to organize and submit their receipts.

From the travel fund recipient's perspective, the biggest advantage of this
approach is that they can use Expensify's phone app to capture receipts as
expenses are incurred during the trip.  At the end of the travel, they
simply log into Expensify, create an expense report, and send it to the
operations@openjsf.org alias for payment.  This will also enable the Foundation
to process payments faster, because the submissions will be uniform.

The old process would still be available as a backup, of course.  However, it's
cumbersome and more time consuming, and will take longer to process.

Signed-off-by: Brian Warner <brian@bdwarner.com>