### PR TITLE
Travel fund request for @christian-bromann for Node + JS Interactive 2019

### DIFF
--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -28,4 +28,4 @@ Weijia | Wang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | Nove
 Gang | Chen | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $530 | October 22 2019 | | | | | |
 Yadong | Ouyang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $400 | October 23 2019 | | | | | |
 Eemeli | Aro | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 14 | 670 USD | November 1 2019 | | | | | |
-Christian | Bromann | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 9 - 15 | 1.133,32 USD | November 9 2019 | https://github.com/nodejs/admin/pull/439 | | | | |
+Christian | Bromann | Node + JS Interactive 2019 | Attendance / Co-Organizing (NJSI + Collab Summit) | | Montreal (Canada) | December 9 - 15 | 1.133,32 USD | November 9 2019 | https://github.com/nodejs/admin/pull/439 | | | | |

--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -21,10 +21,11 @@ Anna | Henningsen | Collaborator Summit | Attendance || Berlin | 30 May - 31 May
 Glenn | Hinks | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | US $1660 | 25 Apr 2019 |||Withdrawn|N/A|N/A|N/A
 Mykola | Grybyk | Collaborator Summit | Attendance || Berlin | 30 May - 31 May 2019 | 320.57€ | 2 May 2019 | ||27 Jun 2019|€320.57|12 Jul 2019|$365
 Abraham | Agiri | OSCA (Open Source Africa) | Facilitator || Lagos NG | 1 - 4 August 2019 | $476.72 | 24 July, 2019 | |19 Aug 2019|$476.72|19 Aug 2019|9 Sep 2019|$476.72
-Richard | Trott | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 16 | $1750 | August 10 2019 | https://github.com/nodejs/admin/pull/401 | | | | | 
-Alejandro | Oviedo | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 16 | $1650 | October 4 2019 | https://github.com/nodejs/admin/pull/418 | | | | | 
-Guy | Bedford | Collaborator Summit | Attendance | | Montreal (Canada) | December 12 - 15 | $577.53 CAD | October 5 2019 | | | | | | 
+Richard | Trott | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 16 | $1750 | August 10 2019 | https://github.com/nodejs/admin/pull/401 | | | | |
+Alejandro | Oviedo | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 16 | $1650 | October 4 2019 | https://github.com/nodejs/admin/pull/418 | | | | |
+Guy | Bedford | Collaborator Summit | Attendance | | Montreal (Canada) | December 12 - 15 | $577.53 CAD | October 5 2019 | | | | | |
 Weijia | Wang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $550 | October 22 2019 | | | | | |
 Gang | Chen | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $530 | October 22 2019 | | | | | |
 Yadong | Ouyang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $400 | October 23 2019 | | | | | |
 Eemeli | Aro | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 14 | 670 USD | November 1 2019 | | | | | |
+Christian | Bromann | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 9 - 15 | 1.133,32 USD | November 9 2019 | | | | | |

--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -28,4 +28,4 @@ Weijia | Wang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | Nove
 Gang | Chen | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $530 | October 22 2019 | | | | | |
 Yadong | Ouyang | COSCon (China Open Source Conf) | C+L Mentor | | Shanghai | November 2-3 | $400 | October 23 2019 | | | | | |
 Eemeli | Aro | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 10 - 14 | 670 USD | November 1 2019 | | | | | |
-Christian | Bromann | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 9 - 15 | 1.133,32 USD | November 9 2019 | | | | | |
+Christian | Bromann | Node + JS Interactive 2019 | Collab Summit, presenting | | Montreal (Canada) | December 9 - 15 | 1.133,32 USD | November 9 2019 | https://github.com/nodejs/admin/pull/439 | | | | |


### PR DESCRIPTION
Travel request for Node + JS Interactive 2019 and Collaborator Summit. I am co-chairing, helping organizing the summit and a project member of the Open JS Foundation.

Airfare: 587.52 Euro
Hotel: 441 Euro (six nights at 73 Euro/night at Travelodge Hotel by Wyndham Montreal Centre)

@nodejs/tsc @nodejs/community-committee