### PR TITLE
Travel Fund request: @jdalton for Node + JS Interactive 2019

### DIFF
--- a/TravelFunds/2019.md
+++ b/TravelFunds/2019.md
@@ -37,3 +37,4 @@ Sam | Roberts | Node + JS Interactive 2019 | Node + JS Interative, Collab Summit
 Jeremiah | Senkpiel | Collab Summit, Montreal 2019 | Collab Summit | | Montreal (Canada) | December 12 - 15 | CAD 1100 | November 30 2019 | https://github.com/nodejs/admin/pull/REPLACEME | | | | |
 Ian | Sutherland | Node + JS Interactive 2019 + Collab Summit | Facilitate Tooling Group meeting at Collab Summit | | Montreal QC, Canada | 2019-12-10 to 2019-12-15 | CAD 1649.39 | 2019-11-25 | https://github.com/nodejs/admin/pull/446 | | | | |
 Anatoli | Papirovski | Node + JS Interactive 2019 + Collab Summit | Collab Summit & Node + JS Interactive 2019 participation | | Montreal QC, Canada | 2019-12-11 to 2019-12-15 | US$ 1203.00 | 2019-12-02 | https://github.com/nodejs/admin/pull/448 | | | | |
+John-David | Dalton | Node + JS Interactive | Attendance | | Montreal (Canada) | December 11-15 | $519 | December 10 2019 | https://github.com/nodejs/admin/pull/450 | | | | |


### PR DESCRIPTION
## Attending Node+JS Interactive
Event: Node+JS Interactive
Event Location: Montreal QC, Canada
Traveling From: Seattle, WA
Doing: Possible participation in Foundation member project panel 
Stipend Size: $519
Foundation member: Yes
Corporate travel fund: None