### PR TITLE
add @BethGriggs to calendar maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The calendar is maintained by:
 <!-- sorted by GitHub handle -->
 - [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**
 - [@bamieh](https://github.com/bamieh) - **Ahmad Bamieh**
+- [@bethgriggs](https://github.com/bethgriggs) - **Beth Griggs**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@dshaw](https://github.com/dshaw) - **Dan Shaw**
 - [@gibfahn](https://github.com/gibfahn) - **Gibson Fahnestock**


### PR DESCRIPTION
I'd like to be able to add the Node.js Release mentoring/shadowing sessions (https://github.com/nodejs/Release/issues/511) to the nodejs.org calendar.

I also host the Node.js Release Working Group meetings, so it would be good to have access to be able to reschedule/remove these from the Node.js calendar when required.