### PR TITLE
docs: add missing time window for social team nomination acceptance

### DIFF
--- a/social-team.md
+++ b/social-team.md
@@ -45,7 +45,7 @@ The Social Team will be responsible for and maintain the following:
 
 ### Nominations
 
-Nominations and self-nominations are open to **project members** on an ongoing basis. An issue should be created in [nodejs/admin](https://github.com/nodejs/admin) for any kind of nomination. After seven days, if a nomination has not been objected to, it is considered accepted.
+Nominations and self-nominations are open to **project members** on an ongoing basis. An issue should be created in [nodejs/admin](https://github.com/nodejs/admin) for any kind of nomination. If there are no objections after seven days, the nomination is automatically accepted.
 
 ### Objections
 

--- a/social-team.md
+++ b/social-team.md
@@ -45,7 +45,7 @@ The Social Team will be responsible for and maintain the following:
 
 ### Nominations
 
-Nominations and self-nominations are open to **project members** on an ongoing basis. An issue should be created in [nodejs/admin](https://github.com/nodejs/admin) for any kind of nomination.
+Nominations and self-nominations are open to **project members** on an ongoing basis. An issue should be created in [nodejs/admin](https://github.com/nodejs/admin) for any kind of nomination. After seven days, if a nomination has not been objected to, it is considered accepted.
 
 ### Objections
 


### PR DESCRIPTION
Brings the social team nomination process in-line with the Moderation Team process, which has a 7 day window for objections. See: the [moderation team](https://github.com/nodejs/admin/blob/master/Moderation-Policy.md#moderation-team) section of the moderation policy.