### PR TITLE
Change the policy when receiving a report to report@nodejs.org

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -96,10 +96,8 @@ All emails sent to the [report@nodejs.org][] address are currently forwarded
 to all members of the Moderation Team.
 
 When a request is sent by email to the [report@nodejs.org][] (or directly to a
-Moderation Team member) a new issue detailing the request must be created in
-the private nodejs/moderation repository. The identity of the individual
-submitting the request should be omitted from the issue unless permission to
-include the identity is provided by the reporter.
+Moderation Team member) the moderation team must log the issue internally and
+report it periodically to the leadership bodies (TSC and CommComm).
 
 Requests should contain as much information and context as possible, including
 the URL and a screenshot of the Post in question. Screenshots may be modified


### PR DESCRIPTION
Suggested by @trott here https://github.com/nodejs/admin/issues/512#issuecomment-646762421 - since there are over 600 people with access to moderation and reports sometimes detail information of members it changes our process from:

 - Open an issue in the moderation repo with some of the report info.

To:

 - Disclose reports (upon request) to the TSC and CommComm

This reduces the visibility of CoC reports from ~700 people (org) to ~50 people (TSC, CommComm and moderation). Rich makes some of the compelling arguments [here](https://github.com/nodejs/admin/issues/512#issuecomment-646762421) and I think the moderation team is in consensus regarding this change (but let's let this PR sit for a few days just to be sure).

cc @nodejs/moderation 

If there is interest, we can add a clause suggesting anonymous publication of what Node.js did to deal with reports in the future.