### PR TITLE
doc: recommend main default branch before transfer

### DIFF
--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -14,6 +14,9 @@ Ideally, the repository should have the following documents in place:
   the project.
 - `README.md`
 
+Make sure the default branch is set to `main` before transfering the repository
+to the org.
+
 ## Step 2. Open an issue in the admin repository
 
 The people opening the issue should be a member of the Node.js organization,

--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -14,8 +14,9 @@ Ideally, the repository should have the following documents in place:
   the project.
 - `README.md`
 
-Make sure the default branch is set to `main` before transfering the repository
-to the org.
+It's recommended to set the default branch to `main` before transferring the
+repository to the org, assuming that's possible without breaking existing
+tooling or workflows.
 
 ## Step 2. Open an issue in the admin repository
 


### PR DESCRIPTION
Our org default branch is set to `main`, so it makes sense 
to also require new repositories being transferred to the org
to follow the same pattern.