### PR TITLE
chore: avoid directing users to HTTP URLs

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -22,7 +22,7 @@ moderation request, please see [Requesting Moderation][]
 
 By default, this policy applies to all repositories under the Node.js GitHub
 Organization and all Node.js Working Groups. This policy also applies to the
-[Node.js Slack Community](http://node-js.slack.com), supported by the Admin
+[Node.js Slack Community](https://node-js.slack.com), supported by the Admin
 team of the Slack organization.
 
 Individual Working Groups may adopt an alternative Moderation Policy for any

--- a/social-team.md
+++ b/social-team.md
@@ -39,7 +39,7 @@ The basic expectations are that **all** Social Team members will have both a wil
 
 The Social Team will be responsible for and maintain the following:
 
-- [nodejs/tweet](http://github.com/nodejs/tweet): a repo leveraging [Twitter Together](https://github.com/gr2m/twitter-together) that enables project members to queue up tweets to [@nodejs](https://twitter.com/nodejs) from within GitHub.
+- [nodejs/tweet](https://github.com/nodejs/tweet): a repo leveraging [Twitter Together](https://github.com/gr2m/twitter-together) that enables project members to queue up tweets to [@nodejs](https://twitter.com/nodejs) from within GitHub.
 
 ## Membership
 


### PR DESCRIPTION
There is no reason to use plain HTTP, it only makes things easier to track/hijack for ISPs and other untrustworthy entities.