### PR TITLE
Document how blocks are kept track of

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -66,6 +66,8 @@ this default policy applies.
     Individuals may choose to
     [block other individuals from their personal GitHub accounts][]. This policy
     does not restrict blocking from personal GitHub accounts.
+  * Blocks are kept track of via the GitHub organization "Moderation Settings"
+    feature as well as issues in the private nodejs/moderation repository.
 * *Requester* refers to an individual requesting Moderation on a Post.
 
 ## Grounds for Moderation


### PR DESCRIPTION
Suggested by @nschonni (thanks!) as part of removing an internal "BLOCKED_USERS" file that was not kept up-to-date.

Note that the policy already states an issue must be open for blocks - so non org-admins can still see what users are blocked at the moment.