### PR TITLE
doc: add nodejs/social-team to list of repos in social-team.md

### DIFF
--- a/social-team.md
+++ b/social-team.md
@@ -40,6 +40,7 @@ The basic expectations are that **all** Social Team members will have both a wil
 The Social Team will be responsible for and maintain the following:
 
 - [nodejs/tweet](https://github.com/nodejs/tweet): a repo leveraging [Twitter Together](https://github.com/gr2m/twitter-together) that enables project members to queue up tweets to [@nodejs](https://twitter.com/nodejs) from within GitHub.
+- [nodejs/social-team](https://github.com/nodejs/social-team): a repo for general discussion, logging, and broad requests made of the Social Team.
 
 ## Membership
 

--- a/social-team.md
+++ b/social-team.md
@@ -39,8 +39,8 @@ The basic expectations are that **all** Social Team members will have both a wil
 
 The Social Team will be responsible for and maintain the following:
 
-- [nodejs/tweet](https://github.com/nodejs/tweet): a repo leveraging [Twitter Together](https://github.com/gr2m/twitter-together) that enables project members to queue up tweets to [@nodejs](https://twitter.com/nodejs) from within GitHub.
 - [nodejs/social-team](https://github.com/nodejs/social-team): a repo for general discussion, logging, and broad requests made of the Social Team.
+- [nodejs/tweet](https://github.com/nodejs/tweet): a repo leveraging [Twitter Together](https://github.com/gr2m/twitter-together) that enables project members to queue up tweets to [@nodejs](https://twitter.com/nodejs) from within GitHub.
 
 ## Membership
 


### PR DESCRIPTION
Adds the social team repo to the list of repos managed by the Social Team.