### PR TITLE
chore: remove CommComm from GITHUB_ORG_MANAGEMENT_POLICY.md

### DIFF
--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -129,7 +129,7 @@ the `fast-track` label to the request, and leave a comment which must contain:
 a) a link showing how the GitHub App or the secret being requested is already 
 in use, and b) ask for approvals to fast-track the request. Two members of the 
 TSC must approve the fast track request. Fast-tracked requests require only 
-need one approval from the TSC, and the request must  remain open for 72 hours.
+one approval from the TSC, and the request must remain open for 72 hours.
 
 If any objection is made, the request may be moved to a vote in the TSC. 
 If the TSC rejects the request, then the request is denied.

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -94,7 +94,7 @@ limitations in the way GitHub permissions are structured.
 To remove any current member from the GitHub organization, an issue must be
 opened in the Node.js admin repository. If, after 72 hours, there are no
 objections from any TSC members, removal becomes automatic. If there are 
-objections, then simple majority votes of each of the Technical Steering
+objections, then a vote of the Technical Steering
 Committee in favor of removal are required.
 
 Blocking an individual who is not currently a member of the GitHub organization

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -57,7 +57,7 @@ Node.js GitHub Organization by opening an issue in the
 Provided there are no objections from any TSC members raised in
 the issue, such requests are approved automatically after 72 hours. If any
 objection is made, the request may be moved to a vote in the
-Technical Steering. If the TSC rejects the request, then the request is denied.
+Technical Steering Committee. If the TSC rejects the request, then the request is denied.
 
 In certain cases, OpenJS Cross Project Council and/or OpenJS Foundation Board
 of Directors approval may also be required.

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -2,15 +2,14 @@
 
 The Node.js GitHub Organization (https://github.com/nodejs) is
 a development resource under the direction
-of the Node.js Technical Steering Committee (TSC) and Node.js Foundation
-Community Committee (CommComm).
+of the Node.js Technical Steering Committee (TSC).
 
 ## Node.js Admin Repository
 
 The [Node.js admin repository][nodejs/admin] serves as the
 central location for managing Node.js GitHub Organization administrative
-activities. Only Node.js GitHub Organization owners, TSC members, and Community
-Committee members have write permissions to the Node.js admin repository.
+activities. Only Node.js GitHub Organization owners and TSC members to 
+the Node.js admin repository.
 
 ## Organization Roles
 
@@ -29,9 +28,8 @@ Owner permissions are granted will be reduced.
 
 The following groups are granted Ownership permissions:
 
-* TSC members
-* Community Committee Chairperson
-* Moderation team members. The Moderation Team members
+* **TSC members.**
+* **Moderation team members.** The Moderation Team members
 will limit their use of the access granted to that required to carry out
 moderation across the existing repositories.
 
@@ -56,11 +54,10 @@ Node.js GitHub Organization by opening an issue in the
 - Archiving an existing repository
 - Transferring a repository into or out of the organization
 
-Provided there are no objections from any TSC or CommComm members raised in
+Provided there are no objections from any TSC members raised in
 the issue, such requests are approved automatically after 72 hours. If any
 objection is made, the request may be moved to a vote in each of the
-Technical Steering and Community Committees. If either the TSC or CommComm
-rejects the request, then the request is denied.
+Technical Steering. If the TSC rejects the request, then the request is denied.
 
 In certain cases, OpenJS Cross Project Council and/or OpenJS Foundation Board
 of Directors approval may also be required.
@@ -70,7 +67,7 @@ of Directors approval may also be required.
 When making a request to create a new repository, specify the team(s) that will
 have write or admin access. If there is not an appropriate team to maintain a
 new repository, request a new team. Approval is automatic if there are no
-objections from TSC or CommComm after 72 hours.
+objections from TSC members after 72 hours.
 
 ## Teams
 
@@ -79,7 +76,7 @@ Group, read that Working Group's governance documentation. For other teams, send
 a join request for the team via the Team page, or, if you are not a member of
 the Node.js org, open an issue on the [Node.js admin repository][nodejs/admin].
 
-For members of teams with org-wide admin permissions (TSC, CommComm and
+For members of teams with org-wide admin permissions (TSC and
 Moderation), it is not possible to send a join request to any teams, since
 those users have permission to add themselves to the team. In this case, use
 your best judgement to decide between adding yourself to the team or asking for
@@ -96,9 +93,9 @@ limitations in the way GitHub permissions are structured.
 
 To remove any current member from the GitHub organization, an issue must be
 opened in the Node.js admin repository. If, after 72 hours, there are no
-objections from any TSC or Community Committee members, removal becomes
-automatic. If there are objections, then simple majority votes of each of the
-Technical Steering and Community Committees in favor of removal are required.
+objections from any TSC members, removal becomes automatic. If there are 
+objections, then simple majority votes of each of the Technical Steering
+in favor of removal are required.
 
 Blocking an individual who is not currently a member of the GitHub organization
 may occur at any time subject to the policies outlined in the Moderation
@@ -108,7 +105,7 @@ Guidelines.
 
 Installation of GitHub apps for one or more repositories, creating personal
 tokens for a project bot account (such as `@nodejs-github-bot`) and adding 
-secrets to a repository must be approved by the TSC and Community Committee.
+secrets to a repository must be approved by the TSC.
 
 In order to request any of the above, open an issue in the 
 [Node.js admin repository][nodejs/admin] with details of:
@@ -123,26 +120,24 @@ In order to request any of the above, open an issue in the
 A new request is required each time an application is enabled or a secret is 
 added for a new repository even if it has been done before.
 
-The request must be approved by at least two TSC and two CommComm members and
-be open for a minimum of 7 days before landing. 
+The request must be approved by at least three TSC members and
+be open for a minimum of 7 days before landing.
 
 For GitHub Apps already used in the Org, or for secrets already used in other
 repositories in the Org, the request can be fast-tracked. To fast-track, add
 the `fast-track` label to the request, and leave a comment which must contain:
 a) a link showing how the GitHub App or the secret being requested is already 
-in use, and b) ask for approvals to fast-track the request. Two members of 
-either TSC or CommComm must approve the fast track request. Fast-tracked 
-requests only need one approval from either TSC or CommComm is required, and 
-the request must  remain open for 72 hours.
+in use, and b) ask for approvals to fast-track the request. Two members of the 
+TSC must approve the fast track request. Fast-tracked requests require only 
+need one approval from the TSC, and the request must  remain open for 72 hours.
 
-If any objection is made, the request may be moved to a vote in each of the
-Technical Steering and Community Committees. If either the TSC or CommComm
-rejects the request, then the request is denied.
+If any objection is made, the request may be moved to a vote in the TSC. 
+If the TSC rejects the request, then the request is denied.
 
 ## Use of Bots and Services
 
 Automation tools such as bots and third-party services on any repository must
-be approved by the TSC and CommComm and are subject to regular security audits.
+be approved by the TSC and are subject to regular security audits.
 Bots that perform actions on behalf of the project (such as moderation or membership
 management actions) are required to maintain a log, accessible to all individuals
 granted Owner permissions, of all actions taken.

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -120,7 +120,7 @@ In order to request any of the above, open an issue in the
 A new request is required each time an application is enabled or a secret is 
 added for a new repository even if it has been done before.
 
-The request must be approved by at least three TSC members and
+The request must be approved by at least two TSC members and
 be open for a minimum of 7 days before landing.
 
 For GitHub Apps already used in the Org, or for secrets already used in other

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -95,7 +95,7 @@ To remove any current member from the GitHub organization, an issue must be
 opened in the Node.js admin repository. If, after 72 hours, there are no
 objections from any TSC members, removal becomes automatic. If there are 
 objections, then a vote of the Technical Steering
-Committee in favor of removal are required.
+Committee in favor of removal is required.
 
 Blocking an individual who is not currently a member of the GitHub organization
 may occur at any time subject to the policies outlined in the Moderation

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -95,7 +95,7 @@ To remove any current member from the GitHub organization, an issue must be
 opened in the Node.js admin repository. If, after 72 hours, there are no
 objections from any TSC members, removal becomes automatic. If there are 
 objections, then simple majority votes of each of the Technical Steering
-in favor of removal are required.
+Committee in favor of removal are required.
 
 Blocking an individual who is not currently a member of the GitHub organization
 may occur at any time subject to the policies outlined in the Moderation

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -8,7 +8,7 @@ of the Node.js Technical Steering Committee (TSC).
 
 The [Node.js admin repository][nodejs/admin] serves as the
 central location for managing Node.js GitHub Organization administrative
-activities. Only Node.js GitHub Organization owners and TSC members to 
+activities. Only Node.js GitHub Organization owners and TSC members have write permissions to 
 the Node.js admin repository.
 
 ## Organization Roles

--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -56,7 +56,7 @@ Node.js GitHub Organization by opening an issue in the
 
 Provided there are no objections from any TSC members raised in
 the issue, such requests are approved automatically after 72 hours. If any
-objection is made, the request may be moved to a vote in each of the
+objection is made, the request may be moved to a vote in the
 Technical Steering. If the TSC rejects the request, then the request is denied.
 
 In certain cases, OpenJS Cross Project Council and/or OpenJS Foundation Board


### PR DESCRIPTION
Initial pass at removing the CommComm from org management. Includes some small changes, including bumping required TSC +1s on an approval from 2 to 3, which is down from the previous 4 total including CommComm approvals. Historically, I've not seen this be a bottleneck so I assume it's fine. I believe it's still good to have more than just two people +1'ing something.