### PR TITLE
meta: add gireeshpunathil to calendar maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This list should be reviewed and pruned annually (at minimum). The calendar has 
 <!-- sorted by GitHub handle -->
 - [@bethgriggs](https://github.com/bethgriggs) - **Beth Griggs**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
+- [@gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil**
 - [@joesepi](https://github.com/joesepi) - **Joe Sepi**
 - [@mcollina](https://github.com/mcollina) - **Matteo Collina**
 - [@mhdawson](https://github.com/mhdawson) - **Michael Dawson**


### PR DESCRIPTION
I have a need to modify the calendar (for example adjusting the diagnostic working group meeting times in response to the working group's needs) . It will be helpful if I have permission to modify the calendar as needed. Thanks in advance!