### PR TITLE
Include discussions in moderation policy

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -51,7 +51,7 @@ this default policy applies.
   more information.
 * *TSC* refers to the [Node.js Technical Steering Committee][].
 * *Post* refers to the content and titles of any issue, pull request, comment,
-  or wiki page.
+  discussion, or wiki page.
 * *Moderate* means to modify, lock, or delete one or more Posts to correct or
   address Code of Conduct violations.
 * *Remove* refers to the act of removing the configured write (commit)


### PR DESCRIPTION
Answers to discussions are comments, but discussions themselves do not fit the current definition of "Post".