### PR TITLE
Update transfer repo instructions to be `nodejs/.github`-aware

### DIFF
--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -16,6 +16,11 @@ Ideally, it would not have the following documents to inherit them from
   Certificate of Origin section in the document to avoid potential copyright
   conflicts.
 
+Note that if the above documents are not checked out on the repository, they
+will appear on the GitHub web UI but not on local clones of the repository. The
+upside is that if the upstream document updates, no action needs to be taken for
+the downstream repository to stay up-to-date.
+
 It's recommended to set the default branch to `main` before transferring the
 repository to the org, assuming that's possible without breaking existing
 tooling or workflows.

--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -4,15 +4,17 @@
 
 Ideally, the repository should have the following documents in place:
 
-- `CODE_OF_CONDUCT.md`: it can be a reference to
-  [the Node.js Code of Conduct][coc].
-- `CONTRIBUTING.md`: if there isn't one already, [the contributing guide][]
-  of Node.js core could be a good example. Consider including the Developer's
-  Certificate of Origin section in the document to avoid potential copyright
-  conflicts.
 - `LICENSE`, or other kind of documents that describe the license of
   the project.
 - `README.md`
+
+Ideally, it would not have the following documents to inherit them from
+[nodejs/.github](https://github.com/nodejs/.github):
+
+- `CODE_OF_CONDUCT.md`.
+- `CONTRIBUTING.md`: if there is one already, consider including the Developer's
+  Certificate of Origin section in the document to avoid potential copyright
+  conflicts.
 
 It's recommended to set the default branch to `main` before transferring the
 repository to the org, assuming that's possible without breaking existing


### PR DESCRIPTION
Refs: https://github.com/nodejs/.github/pull/2
Refs: https://github.com/nodejs/.github/pull/3

@nodejs/tsc 