### PR TITLE
add moderation team to member expectations

### DIFF
--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -1,6 +1,7 @@
 All participants in the Node.js project must follow the
 [Code of Conduct](CODE_OF_CONDUCT.md). There are further expectations for
-members of the [TSC](https://github.com/nodejs/TSC).
+members of the [TSC](https://github.com/nodejs/TSC) and
+[Moderation Team](https://github.com/nodejs/admin/blob/main/Moderation-Policy.md#moderation-team).
 
 When decisions are made within the established guidelines and policies of the
 project, those in leadership roles have a responsibility to uphold and respect


### PR DESCRIPTION
The moderation policy indicates that member expectations apply to
moderation team, but the member expectations document only specifies
TSC. Add moderation team.