### PR TITLE
remove obsolete sentence

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -47,8 +47,6 @@ team of the Slack organization.
     Individuals may choose to
     [block other individuals from their personal GitHub accounts][]. This policy
     does not restrict blocking from personal GitHub accounts.
-  * Blocks are kept track of via the GitHub organization "Moderation Settings"
-    feature as well as issues in the private nodejs/moderation repository.
 * *Requester* refers to an individual requesting Moderation on a Post.
 
 ## Grounds for Moderation


### PR DESCRIPTION
We don't keep a list of blocked accounts, although GitHub does. However we don't need to mention that in the policy.