### PR TITLE
Update moderation team slack channel

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -270,7 +270,7 @@ in favor of the nomination is required.
 *Onboarding*
 
 New Moderation Team members are onboarded with:
-- an invite to Node.js Moderation Team Slack
+- an invite to Node.js Moderation Team channel in the OpenJS Slack
 - permission changes made to GitHub to allow access to moderate
 - a walkthrough of relevant processes, expectations, and documents by an existing Moderation Team member
 - access to existing documents


### PR DESCRIPTION
We've tried moving to the OpenJS slack from our own slack instance to reduce duplications and having "an extra workspace just for that" and simplify things.

It looks like everyone is here - so this change makes it formal (hopefully).