### PR TITLE
chore: remove "self-moderate" from Moderation Policy

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -195,8 +195,8 @@ Scenario 1:
 
 Scenario 2:
  * A non-Collaborator posts a comment that is against the Code of Conduct.
- * A Collaborator sees the comment and asks the author to self-moderate.
- * The author refuses to self-moderate.
+ * A Collaborator sees the comment and asks the author to edit it.
+ * The author refuses to edit their comment.
  * The Collaborator deletes the comment and posts an issue in the moderation
    repository explaining their actions.
 


### PR DESCRIPTION
The term "self-moderate" is probably clear in the context of the Moderation Policy, but it has become a bit of our project's jargon and it's not clear that people generally understand what the term means. It is unnecessary in the Moderation Policy context. I think "edit their comment" is more clear in the context used here.