### PR TITLE
 update GITHUB_ORG_MANAGEMENT_POLICY.md to document OpenJS access

### DIFF
--- a/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -33,6 +33,9 @@ Owner permissions are granted will be reduced.
 The following groups are granted Ownership permissions:
 
 * **TSC members.**
+* **OpenJS Director of Program Management** The OpenJS Director of Program
+  Management will limit their use of the access granted to:
+    * accepting GitHub terms and conditions.
 * **Moderation team members.** The Moderation Team members
 will limit their use of the access granted to that required to carry out
 moderation across the existing repositories.


### PR DESCRIPTION
Update to document that the OpenJS Directory of Program Management is an org owner along with what they will use this access for.