### PR TITLE
doc: add marco-ippolito as calendar maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This list should be reviewed and pruned annually (at minimum). The calendar has 
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil**
 - [@joesepi](https://github.com/joesepi) - **Joe Sepi**
+- [@marco-ippolito](https://github.com/marco-ippolito) - **Marco Ippolito**
 - [@mcollina](https://github.com/mcollina) - **Matteo Collina**
 - [@mhdawson](https://github.com/mhdawson) - **Michael Dawson**
 - [@MylesBorins](https://github.com/MylesBorins) - **Myles Borins**


### PR DESCRIPTION
I'd like to add myself as calendar maintainer to manage https://github.com/nodejs/typescript team meetings
Ping @nodejs/tsc 