### PR TITLE
Update Moderation Policy to handle LLM "contributions"

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -179,6 +179,13 @@ of the [Code of Conduct][].
   by the TSC) are subject to immediate Blocking.
 * Issues, pull requests, discussions, and comments that are spam (job posting,
   service advertising, etc.) are subject to immediate moderation.
+* Issues, pull requests, discussions, and comments that are belived to be
+  LLM-generated (e.g a PR coming from a new contributor changing a single file
+  without clear motivation) should be closed with a comment such as "If you are
+  using a LLM, please stop, this is not bringing any value and wasting our time.
+  If you are not using one, please read and follow our contributing guidelines."
+  Report the user to the moderation repository so they get block if they do it
+  again.
 * Collaborators may use the Hide feature in the GitHub interface for off-topic
   posts by non-Collaborators.
 * Moderation Team members and TSC voting members can delete any issues or

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -181,11 +181,11 @@ of the [Code of Conduct][].
   service advertising, etc.) are subject to immediate moderation.
 * Issues, pull requests, discussions, and comments that are believed to be
   LLM-generated (e.g a PR coming from a new contributor changing a single file
-  without clear motivation) should be closed with a comment such as "If you are
-  using a LLM, please stop, this is not bringing any value and is wasting our time.
-  If you are not using one, please read and follow our contributing guidelines."
-  Report the user to the moderation repository so they get blocked if they do it
-  again.
+  without clear motivation) should be closed with a comment such as "It seems
+  you are using a LLM, please stop, this is not bringing any value and is
+  wasting our time. If you are not using one, please read and follow our
+  contributing guidelines." Report the user to the moderation repository so they
+  get blocked if they do it again.
 * Collaborators may use the Hide feature in the GitHub interface for off-topic
   posts by non-Collaborators.
 * Moderation Team members and TSC voting members can delete any issues or

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -179,12 +179,12 @@ of the [Code of Conduct][].
   by the TSC) are subject to immediate Blocking.
 * Issues, pull requests, discussions, and comments that are spam (job posting,
   service advertising, etc.) are subject to immediate moderation.
-* Issues, pull requests, discussions, and comments that are belived to be
+* Issues, pull requests, discussions, and comments that are believed to be
   LLM-generated (e.g a PR coming from a new contributor changing a single file
   without clear motivation) should be closed with a comment such as "If you are
-  using a LLM, please stop, this is not bringing any value and wasting our time.
+  using a LLM, please stop, this is not bringing any value and is wasting our time.
   If you are not using one, please read and follow our contributing guidelines."
-  Report the user to the moderation repository so they get block if they do it
+  Report the user to the moderation repository so they get blocked if they do it
   again.
 * Collaborators may use the Hide feature in the GitHub interface for off-topic
   posts by non-Collaborators.


### PR DESCRIPTION
It seems likely that the volume of LLM-generated PRs and comments is going to increase, and a lot of it is just noise tbh, bringing no value for the contributor nor the project, and wasting reviewers' time. Since those do not exactly fit "bot" nor "spam" categories, I suggest we create a new category for those, slightly more forgiving since it's probably fair to assume there's an actual human behind.

I don't know if it needs to be explicitly stated, using an LLM is not the problem per-se, as long as the contribution has value and the contributor is able to back it up – so basically "if you act like a bot, don't complain about being treated as one". 