### PR TITLE
Request token for `nodejs/nodejs.org`

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,7 +51,7 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
-[`nodejs/require-in-the-middle`][]    | `GH_USER_TOKEN`               | XXXX-XX-XX      | <https://github.com/nodejs/admin/pull/966> |
+[`nodejs/nodejs.org`][]    | `GH_USER_TOKEN`               | XXXX-XX-XX      | <https://github.com/nodejs/admin/pull/966> |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release

--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,7 +51,7 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
-[`nodejs/require-in-the-middle`][]    | `GH_USER_TOKEN`               | XXXX-XX-XX      | <https://github.com/nodejs/admin/pull/XXX> |
+[`nodejs/require-in-the-middle`][]    | `GH_USER_TOKEN`               | XXXX-XX-XX      | <https://github.com/nodejs/admin/pull/966> |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release

--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,6 +51,7 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
+[`nodejs/require-in-the-middle`][]    | `GH_USER_TOKEN`               | XXXX-XX-XX      | <https://github.com/nodejs/admin/pull/XXX> |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release
@@ -58,5 +59,6 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/import-in-the-middle`]: https://github.com/nodejs/import-in-the-middle
 [`nodejs/node-core-utils`]: https://github.com/nodejs/node-core-utils
 [`nodejs/node-gyp`]: https://github.com/nodejs/node-gyp
+[`nodejs/nodejs.org`]: https://github.com/nodejs/nodejs.org
 [`nodejs/require-in-the-middle`]: https://github.com/nodejs/require-in-the-middle
 [`nodejs/wasm-builder`]: https://github.com/nodejs/wasm-builder


### PR DESCRIPTION
Ref: https://github.com/nodejs/nodejs.org/pull/7671

We would like a `GH_USER_TOKEN` with:
```yaml
contents: write
pull-requests: write
```

This will allow us to trigger `pull_request` workflows from our Crowdin action.