### PR TITLE
Create a directory for funding individual contributors

### DIFF
--- a/fund-individual-contributors.md
+++ b/fund-individual-contributors.md
@@ -1,0 +1,9 @@
+# Fund individual contributors
+
+The following directory lists maintainers who are open to receiving funding:
+
+Name        | Contact               | Areas of interest and expertise |
+------------|-----------------------|---------------------------------|
+Darshan Sen | <raisinten@gmail.com> | Single executable applications  |
+
+Companies and individuals may connect directly with maintainers. The Node.js project does not oversee these engagements and is not responsible for any disputes or outcomes.


### PR DESCRIPTION
This is a follow-up of https://github.com/nodejs/TSC/issues/1747.

This creates a directory of maintainers who are open to receive funding. The goal is to provide visibility and a simple way for users and organizations to support individual maintainers directly.

The initial version of the list includes just myself, with the structure in place for others to be added as they opt in.

cc @nodejs/tsc 