### PR TITLE
doc: request token for wiby

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,6 +51,7 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
+[`pkgjs/wiby`][]                      | `WIBY_TOKEN`                  | 2026-07-11      | TODO                                       |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release
@@ -60,3 +61,4 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`]: https://github.com/nodejs/node-gyp
 [`nodejs/require-in-the-middle`]: https://github.com/nodejs/require-in-the-middle
 [`nodejs/wasm-builder`]: https://github.com/nodejs/wasm-builder
+[`pkgjs/wiby`]: https://github.com/pkgjs/wiby


### PR DESCRIPTION
Should fix https://github.com/nodejs/package-maintenance/issues/629

This token should have push access to the following repositories:

- https://github.com/wiby-test/partial
- https://github.com/wiby-test/fail
- https://github.com/wiby-test/pass

```
permissions:
  contents: write
  pull-requests: write
  statuses: read
``` 

The bot that has access to this is called @wiby-bot, and the access credentials are in Node.js's 1Password.

<img width="215" height="138" alt="imagen" src="https://github.com/user-attachments/assets/e25a0202-f0ba-41ca-9323-77a283c8090d" />
<img width="156" height="76" alt="imagen" src="https://github.com/user-attachments/assets/5ade3f00-febd-4533-845f-29e8760cea38" />

