### PR TITLE
remove Ulises from Moderation Team

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -317,8 +317,6 @@ remove resigning team member from respective permissions and private access.
   **Jordan Harband** <<ljharb@gmail.com>> (he/him)
 * [othiym23](https://github.com/othiym23) -
   **Forrest L Norvell** &lt;othiym23@gmail.com&gt;
-* [UlisesGascon](https://github.com/ulisesgascon) -
-  **Ulises Gascón** <<ulisesgascongonzalez@gmail.com>> (he/him)
 
 ### Admins for Node.js Slack community
 


### PR DESCRIPTION
I’ll be stepping back from moderation for a few months. Life has shifted a bit, with changing priorities between family, work, and other commitments. I won’t be able to dedicate the time and attention that moderation deserves right now.

I really admire the work you’re all doing. It’s clear how much care and effort goes into making this project a safe and welcoming space. Thank you for that :heart: 
