### PR TITLE
Update the moderation policy to OpenJS escalation path, have TSC handle TSC reports

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -336,7 +336,9 @@ remove resigning team member from respective permissions and private access.
 Any code of conduct report, and any decision made by the moderation team, can
 be escalated to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
 
-Upon request, any information regarding an escalated report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team after approval by the TSC.
+Upon request, any information regarding an escalated report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team
+after notifying all the parties involved and the TSC.
+
 ## Reports regarding TSC and Moderation team members
 
 Moderation disputes involving TSC or Moderation Team members,

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -331,23 +331,22 @@ remove resigning team member from respective permissions and private access.
 * [ljharb](https://github.com/ljharb) -
   **Jordan Harband** &lt;ljharb@gmail.com&gt;
 
-## Escalation of Issues
+## Escalation of issues
 
-Moderation issue disputes not involving a TSC voting member or Moderation Team
-member may be escalated to the TSC for review by tagging the
-original issue, pull request, or associated nodejs/moderation repository
-tracking issue with the `moderation-review` label. Any such Moderation action
-may be overturned through a TSC vote.
+Any decisions done by the moderation team can be escalated to the
+[OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
+
+## Reports regarding TSC and Moderation team members
+
+Moderation disputes involving TSC or Moderation Team members,
+including questions of whether a TSC or Moderation Team member has
+violated the Code of Conduct, are to be handled by the other TSC members.
+This process will be mediated by a volunteer from the moderation team.
 
 TSC or Moderation Team members directly involved in a Moderation
 issue (as either the Requester or author of the Post in question) are
 required to recuse themselves from any decisions required to resolve the
 issue.
-
-Moderation disputes involving TSC or Moderation Team members,
-including questions of whether a TSC or Moderation Team member has
-violated the Code of Conduct, *shall* be referred to an Independent Mediator
-selected by the OpenJS Foundation.
 
 ## Modifications to This Policy
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -339,6 +339,14 @@ be escalated to the [OpenJS Code of Conduct Team](https://github.com/openjs-foun
 Upon request, any information regarding an escalated report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team
 after notifying all the parties involved and the TSC.
 
+## Appeal of issues
+
+Any code of conduct report, and any decision made by the moderation team, can
+be appealed to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#appeal).
+
+Upon request, any information regarding an appeleaded report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team
+after notifying all the parties involved and the TSC.
+
 ## Reports regarding TSC and Moderation team members
 
 Moderation disputes involving TSC or Moderation Team members,

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -333,8 +333,8 @@ remove resigning team member from respective permissions and private access.
 
 ## Escalation of issues
 
-Any decisions done by the moderation team can be escalated to the
-[OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
+Any code of conduct report, and any decision made by the moderation team, can
+be escalated to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
 
 ## Reports regarding TSC and Moderation team members
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -334,18 +334,14 @@ remove resigning team member from respective permissions and private access.
 ## Escalation of issues
 
 Any code of conduct report, and any decision made by the moderation team, can
-be escalated to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
-
-Upon request, any information regarding an escalated report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team
-after notifying all the parties involved and the TSC.
+be escalated to the OpenJS Code of Conduct Team
+following the [escalation process](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
 
 ## Appeal of issues
 
 Any code of conduct report, and any decision made by the moderation team, can
-be appealed to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#appeal).
-
-Upon request, any information regarding an appeleaded report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team
-after notifying all the parties involved and the TSC.
+be appealed to the OpenJS Code of Conduct Team
+following the [appeal process](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#appeals).
 
 ## Reports regarding TSC and Moderation team members
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -336,6 +336,7 @@ remove resigning team member from respective permissions and private access.
 Any code of conduct report, and any decision made by the moderation team, can
 be escalated to the [OpenJS Code of Conduct Team](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation).
 
+Upon request, any information regarding an escalated report requested by the OpenJS Code of Conduct team will be supplied to them by the moderation team after approval by the TSC.
 ## Reports regarding TSC and Moderation team members
 
 Moderation disputes involving TSC or Moderation Team members,


### PR DESCRIPTION
This change updates the escalation path from an 8-year-old process defined in the Node.js Foundation era to what was agreed to when the OpenJS Foundation was established. We should have done it long ago, but we forgot to update this one.

I took the occasion to remove the `moderation-review` label and directly upstream the problem of escalation to the OpenJS CoC Team. _Alternatively_, we could have an internal appeal process plus the OpenJS appeal process.

I've also changed the verbiage to have the TSC self-moderate.

The current set of documents from OpenJS can be found at https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md#escalation.