### PR TITLE
chore(doc-kit): request PAT

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,6 +51,7 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
+[`nodejs/doc-kit`][]                  | `DOC_KIT_BOT_PAT`             |                 |                                            |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release
@@ -60,3 +61,4 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`]: https://github.com/nodejs/node-gyp
 [`nodejs/require-in-the-middle`]: https://github.com/nodejs/require-in-the-middle
 [`nodejs/wasm-builder`]: https://github.com/nodejs/wasm-builder
+[`nodejs/doc-kit`]: https://github.com/nodejs/doc-kit


### PR DESCRIPTION
Ref: https://github.com/nodejs/doc-kit/pull/377

The default `GITHUB_TOKEN` provided by GitHub does not trigger workflow runs (see: https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs). To ensure that bot-created pull requests trigger workflows, we need to use a bot's personal access token instead.

So, I'm requesting a @nodejs-github-bot PAT with ``contents: write`` access to `nodejs/doc-kit`. 

CC @nodejs/web-infra 