### PR TITLE
feat(token): revoke `doc-kit` PAT

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -51,7 +51,6 @@ Repo                                  | Secret name                   | Expirati
 [`nodejs/node-gyp`][]                 | `GH_USER_TOKEN`               | 2026-01-28      | <https://github.com/nodejs/admin/pull/935> |
 [`nodejs-private/security-release`][] | `SECURITY_WG_GITHUB_TOKEN`    | 2026-02-06      | <https://github.com/nodejs/admin/pull/950> |
 [`nodejs/require-in-the-middle`][]    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-02-07      | <https://github.com/nodejs/admin/pull/951> |
-[`nodejs/doc-kit`][]                  | `DOC_KIT_BOT_PAT`             | 2026-08-06      | <https://github.com/nodejs/admin/pull/996> |
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot
 [`nodejs-private/security-release`]: https://github.com/nodejs-private/security-release


### PR DESCRIPTION
**Blocked** by https://github.com/nodejs/doc-kit/pull/417. Once that PR lands, Dependabot will be used for updating these internal packages, and a PAT will no longer be needed.