### PR TITLE
doc: add sxa as calendar maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,6 @@ This list should be reviewed and pruned annually (at minimum). The calendar has 
 - [@mhdawson](https://github.com/mhdawson) - **Michael Dawson**
 - [@RafaelGSS](https://github.com/RafaelGSS) - **Rafael Gonzaga**
 - [@ruyadorno](https://github.com/ruyadorno) - **Ruy Adorno**
+- [@sxa](https://github.com/sxa) - **Stewart Addison**
 
 [`@nodejs-github-bot`]: https://github.com/nodejs-github-bot


### PR DESCRIPTION
Adding myself after a discussion with @richardlau about some potential discrepencies with the current data, potentially as a result of [some meetings moving to LFX](https://github.com/nodejs/admin/issues/1024).

Noting that I already have access to zoom as per https://github.com/nodejs/email/blob/8e7172f12f7d4d7507effe35e9893eb3d6897ebb/iojs.org/aliases.json#L215 so this part of helping to assist in hosting project meetings going forward.