### PR TITLE
fix: add @avivkeller as calendar maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This list should be reviewed and pruned annually (at minimum). The calendar has 
 ### Calendar Maintainers
 
 <!-- sorted by GitHub handle -->
+- [@avivkeller](https://github.com/avivkeller) - **Aviv Keller**
 - [@gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil**
 - [@joesepi](https://github.com/joesepi) - **Joe Sepi**
 - [@joyeecheung](https://github.com/joyeecheung) - **Joyee Cheung**


### PR DESCRIPTION
I already have this access on LFX, however, it's not documented anywhere.

<img width="1007" height="598" alt="image" src="https://github.com/user-attachments/assets/a743f590-dc16-4eeb-94e4-6f7b43fd96da" />
