### PR TITLE
chore: Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly


### PR DESCRIPTION
Noticed that the one Action is running an older version of `actions/checkout`. Rather than a one-off bump, adds Dependabot to open PRs as needed.
Kept the frequency to Monthly to minimize noise.