### PR TITLE
Add org policy to prevent accidental repo transfer

### DIFF
--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -47,11 +47,11 @@ is approved.
 
 ## Step 3. Transfer the repository
 
-When the request is approved, the owner of the repository can be added to the allow list of the
-[Organisation Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories)
-so they can start transferring the repository into the Node.js GitHub organization. The person can
-be made a member of the Node.js GitHub organization so they have the necessary permissions
-to complete the transfer. After the transfer is complete, the allow list should be emptied.
+When the request is approved, the owner of the repository can start transferring
+the repository into the Node.js GitHub organization. The person can be made a
+member of the Node.js GitHub organization so they have the necessary permissions
+to complete the transfer. A TSC member will need to approve the bypass request for the
+[Organisation Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories).
 
 See [GitHub's documentation on transferring repos][] on how to perform the
 necessary actions.

--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -52,7 +52,7 @@ the repository into the Node.js GitHub organization. The person can be made a
 member of the Node.js GitHub organization so they have the necessary permissions
 to complete the transfer. A TSC member will need to approve the
 [bypass request](https://github.com/organizations/nodejs/settings/rules/bypass_requests) for the
-[Organisation Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories).
+[Organization Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories).
 
 See [GitHub's documentation on transferring repos][] on how to perform the
 necessary actions.

--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -50,7 +50,8 @@ is approved.
 When the request is approved, the owner of the repository can start transferring
 the repository into the Node.js GitHub organization. The person can be made a
 member of the Node.js GitHub organization so they have the necessary permissions
-to complete the transfer. A TSC member will need to approve the bypass request for the
+to complete the transfer. A TSC member will need to approve the
+[bypass request](https://github.com/organizations/nodejs/settings/rules/bypass_requests) for the
 [Organisation Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories).
 
 See [GitHub's documentation on transferring repos][] on how to perform the

--- a/transfer-repo-into-the-org.md
+++ b/transfer-repo-into-the-org.md
@@ -47,10 +47,11 @@ is approved.
 
 ## Step 3. Transfer the repository
 
-When the request is approved, the owner of the repository can start transferring
-the repository into the Node.js GitHub organization. The person can be made a
-member of the Node.js GitHub organization so they have the necessary permissions
-to complete the transfer.
+When the request is approved, the owner of the repository can be added to the allow list of the
+[Organisation Repository Policy](https://github.com/organizations/nodejs/settings/policies/repositories)
+so they can start transferring the repository into the Node.js GitHub organization. The person can
+be made a member of the Node.js GitHub organization so they have the necessary permissions
+to complete the transfer. After the transfer is complete, the allow list should be emptied.
 
 See [GitHub's documentation on transferring repos][] on how to perform the
 necessary actions.


### PR DESCRIPTION
GitHub has a feature to limit repository transfers which we could take advantage of. Accidental transfers (or at least transfers that did not follow the process) is certainly something that has happened, and while they are generally not a big deal, it's probably better to raise the bar to make malicious account takeover less appealing.

I've just tried it, here's what it looks like when trying to make a repository change:

<img width="667" height="663" alt="image" src="https://github.com/user-attachments/assets/b72bc187-4bbf-4bc7-9598-5f4770778273" />

And here's how it looks from the approver side:

<img width="818" height="841" alt="image" src="https://github.com/user-attachments/assets/eae6e3d2-cba9-4491-8ace-71b7abba3531" />


Looks like we need to define who the approvers, TSC would be the logical group.

Refs: https://docs.github.com/en/enterprise-cloud@latest/enterprise-onboarding/govern-people-and-repositories/create-repository-policies