### PR TITLE
Add blocking rule for excessive PRs or issues

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -178,7 +178,7 @@ of the [Code of Conduct][].
 * Accounts that are reasonably believed to be bots (other than bots authorized
   by the TSC) are subject to immediate Blocking.
 * Users who open PRs or issues faster than they can be reviewed or triaged
-  (e.g. >3 per day) are subject to immediate Blocking.
+  (e.g. >3 per day) are subject to immediate moderation.
 * Issues, pull requests, discussions, and comments that are spam (job posting,
   service advertising, etc.) are subject to immediate moderation.
 * Issues, pull requests, discussions, and comments in violation of the [AI use

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -177,6 +177,8 @@ of the [Code of Conduct][].
   an exception to the reporting requirement described above.
 * Accounts that are reasonably believed to be bots (other than bots authorized
   by the TSC) are subject to immediate Blocking.
+* Users who open PRs or issues faster than they can be reviewed or triaged
+  (e.g. >3 per day) are subject to immediate Blocking.
 * Issues, pull requests, discussions, and comments that are spam (job posting,
   service advertising, etc.) are subject to immediate moderation.
 * Issues, pull requests, discussions, and comments in violation of the [AI use


### PR DESCRIPTION
In a similar spirit as https://github.com/nodejs/node/pull/65250, but is not an option GH offers AFAIK so would be manual moderation action. It's always been the case that sending too many PRs (or too big PRs) would result in you not getting reviews, but because the cost of sending a PR is much lower in the age of coding agents, it's better for the project to desincentivize this behavior as it has a toll on the whole project.
