### PR TITLE
chore: renew import-in-the-middle release token

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -44,7 +44,7 @@ permission scope changes. The PR should describe the permission scopes requested
 
 Repo                                  | Secret name                   | Expiration date | Pull Request                                |
 ---                                   | ---                           | ---             | ---                                         |
-[`nodejs/import-in-the-middle`][]     | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-08-06      | <https://github.com/nodejs/admin/pull/902>  |
+[`nodejs/import-in-the-middle`][]     | `RELEASE_PLEASE_GITHUB_TOKEN` | 2027-08-28      | <https://github.com/nodejs/admin/pull/902>  |
 [`nodejs/node-core-utils`][]          | `RELEASE_PLEASE_GITHUB_TOKEN` | 2026-09-18      | <https://github.com/nodejs/admin/pull/915>  |
 [`nodejs/wasm-builder`][]             | `RELEASE_PLEASE_GITHUB_TOKEN` | 2027-01-14      | <https://github.com/nodejs/admin/pull/926>  |
 [`nodejs/amaro`][]                    | `RELEASE_PLEASE_GITHUB_TOKEN` | 2027-01-14      | <https://github.com/nodejs/admin/pull/933>  |


### PR DESCRIPTION
The `nodejs/import-in-the-middle` release token expired on 2026-08-06. Please create its replacement for `@nodejs-github-bot` with these permissions:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Store it as `RELEASE_PLEASE_GITHUB_TOKEN`.

Refs: https://github.com/nodejs/admin/pull/902
