### PR TITLE
Add when to use a token section

### DIFF
--- a/request-an-access-token.md
+++ b/request-an-access-token.md
@@ -27,14 +27,30 @@ steps as:
 Fine-grained tokens created with access to https://github.com/nodejs resources will
 be audited at https://github.com/organizations/nodejs/settings/personal-access-tokens/active.
 
+## When to use a nodejs-github-bot token
+
+By default, GitHub built-in token for an action workflow `secrets.GITHUB_TOKEN` does not
+trigger recursive workflow runs. If a workflow requires an exceptional case to trigger
+recursive workflow runs, or cross-repository workflows, file a PR as documented above.
+
+GitHub also introduced `approval-required` state, which allows manual approving workflow
+to run on automated PRs. It is recommended to use GitHub action permission control to
+improve workflow securities.
+
+The commonly known cases are as follows:
+
+- Cross repo deployment: request a nodejs-github-bot token.
+- Release Please: use `approval-required` state instead.
+- Updating a dependency: use `approval-required` state instead.
+
 ## Registry
 
 The "repo" is a string of the GitHub `<owner>/<repo>`. Generally, the token should
 only be created for repo in the https://github.com/nodejs organization.
 
 The "secret name" is a string that the secret can be referenced in the GitHub Action
-scripts. Like a secret name of `RELEASE_PLEASE_TOKEN` can be accessed from the script
-as `${{ secrets.RELEASE_PLEASE_TOKEN }}`.
+scripts. Like a secret name of `DEPLOY_TOKEN` can be accessed from the script
+as `${{ secrets.DEPLOY_TOKEN }}`.
 
 The "expiration date" is the date before which the token should be renewed and
 replaced. This should be no longer than 1 year.


### PR DESCRIPTION
GitHub introduced `approval-required` state for recursive workflow runs: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow. This could alleviate some cases from using a PAT by manually approve workflow runs for an automated PR, such as release-please.

The approval UI is identical to a first-time-contributor opening a PR.

<img width="819" height="102" alt="image" src="https://github.com/user-attachments/assets/d43c8c7f-c335-4688-98e4-2255183ffb56" />


We could decommission some of the tokens on the registry.